### PR TITLE
Add central sun with orbiting planets

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,19 +150,28 @@ function initStars(reset=false){
   if(reset){ starCells.clear(); }
 }
 
-// =============== Stacje & NPC (stała siatka) ===============
-const STATION_COORDS = (() => {
-  const list = []; const cols = 6, rows = 4;
-  const sx = WORLD.w/(cols+1), sy = WORLD.h/(rows+1);
-  let seed = 1337; const rnd = ()=> (seed = (seed*1664525+1013904223)|0, ((seed>>>0)%10000)/10000);
-  for(let j=1;j<=rows;j++) for(let i=1;i<=cols;i++){
-    const x = Math.round(i*sx + (rnd()-0.5)*sx*0.35);
-    const y = Math.round(j*sy + (rnd()-0.5)*sy*0.35);
-    list.push({x,y,r:48+Math.floor(rnd()*36)});
+// =============== Słońce i orbitujące planety/stacje ===============
+const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200 };
+const STATION_DATA = (() => {
+  const orbitRadii = [4000, 8000, 12000, 12500, 16000, 20000, 24000, 28000];
+  const list = [];
+  for (let i = 0; i < orbitRadii.length; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 0.02 + Math.random() * 0.01;
+    const r = 48 + Math.floor(Math.random() * 36);
+    list.push({ id: i, orbitRadius: orbitRadii[i], angle, speed, r });
   }
   return list;
 })();
-let stations = STATION_COORDS.map((p,idx)=>({id:idx, x:p.x, y:p.y, r:p.r}));
+let stations = STATION_DATA.map(p => ({
+  id: p.id,
+  orbitRadius: p.orbitRadius,
+  angle: p.angle,
+  speed: p.speed,
+  r: p.r,
+  x: SUN.x + Math.cos(p.angle) * p.orbitRadius,
+  y: SUN.y + Math.sin(p.angle) * p.orbitRadius,
+}));
 
 const NPC_COUNT = 30;
 let npcs = [];
@@ -179,7 +188,7 @@ function initNPCs(){
   }
 }
 initNPCs();
-initPlanets3D(stations);
+initPlanets3D(stations, SUN);
 
 // =============== Bullets & effects ===============
 const bullets = [];
@@ -577,6 +586,12 @@ function engageWarp(dir){
 
 // =============== Fizyk ===============
 function physicsStep(dt){
+  // aktualizacja orbit planet/stacji
+  for(const st of stations){
+    st.angle += st.speed * dt;
+    st.x = SUN.x + Math.cos(st.angle) * st.orbitRadius;
+    st.y = SUN.y + Math.sin(st.angle) * st.orbitRadius;
+  }
   // regen paliwa gdy nie warpuje
   if(warp.state!=='active') warp.fuel = clamp(warp.fuel + warp.regenRate*dt, 0, warp.fuelMax);
   if(boost.state==='idle' && boost.effectTime<=0) boost.fuel = clamp(boost.fuel + boost.regenRate*dt, 0, boost.fuelMax);


### PR DESCRIPTION
## Summary
- Add central 3D sun and generate eight planets/stations with specified orbital distances
- Animate planetary orbits and include close orbit for planets 3 and 4
- Extend 3D rendering to draw the sun and keep planet models aligned with their moving stations

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ac3c7f3f5c83258dada6de2bd624fb