### PR TITLE
Add in-game clock and scale planet orbits

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <body>
   <div id="ui">
     <div><strong>Space Survivors — gwiazdy na całej mapie + duży silnik plazmowy</strong></div>
+    <div class="stat">Czas gry: <span id="game-time">00:00</span></div>
     <div class="stat">W — ciąg (duży silnik plazmowy) · Q/E — strafe · A/D — obrót</div>
     <div class="stat">LPM — rail (A→B, A→B) · PPM — boczne rakiety · F — superbroń · SHIFT — warp · SPACJA — dopalacz</div>
     <div style="margin-top:6px"><small>Gwiazdy są proceduralne w całej galaktyce. Silnik: niebieski exhaust + krótki ślad przy ruchu.</small></div>
@@ -38,6 +39,17 @@ const len = v=>Math.hypot(v.x,v.y);
 const norm = v=>{ const L=len(v); return L?{x:v.x/L,y:v.y/L}:{x:0,y:0}; };
 function rotate(local,a){ const c=Math.cos(a), s=Math.sin(a); return {x: local.x*c - local.y*s, y: local.x*s + local.y*c}; }
 function rotateInv(world,a){ return rotate(world, -a); }
+
+// =============== Game time (1 min real = 1 h game) ===============
+const TIME_SCALE = 60; // game seconds per real second
+let gameTime = 0; // seconds
+const gameTimeEl = document.getElementById('game-time');
+function formatGameTime(sec){
+  const t = Math.floor(sec);
+  const h = Math.floor(t / 3600) % 24;
+  const m = Math.floor((t % 3600) / 60);
+  return `${h.toString().padStart(2,'0')}:${m.toString().padStart(2,'0')}`;
+}
 function wrapAngle(a){ while(a>Math.PI) a-=2*Math.PI; while(a<-Math.PI) a+=2*Math.PI; return a; }
 function interpAngleShort(prev,curr,t){ const d = wrapAngle(curr - prev); return wrapAngle(prev + d * t); }
 function shuffleArray(a){ for(let i=a.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } }
@@ -153,13 +165,17 @@ function initStars(reset=false){
 // =============== Słońce i orbitujące planety/stacje ===============
 const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200 };
 const STATION_DATA = (() => {
-  const orbitRadii = [4000, 8000, 12000, 12500, 16000, 20000, 24000, 28000];
+  const AU = [0.39, 0.72, 1.0, 1.52, 5.2, 9.58, 19.2, 30.05];
+  const BASE_ORBIT = 7000; // distance scale
   const list = [];
-  for (let i = 0; i < orbitRadii.length; i++) {
+  for (let i = 0; i < AU.length; i++) {
+    const au = AU[i];
+    const orbitRadius = BASE_ORBIT * Math.pow(au, 0.6);
     const angle = Math.random() * Math.PI * 2;
-    const speed = 0.02 + Math.random() * 0.01;
+    const periodHours = 24 * Math.pow(au, 1.5); // Kepler scaling
+    const speed = (2 * Math.PI) / (periodHours * 3600); // rad per game second
     const r = 48 + Math.floor(Math.random() * 36);
-    list.push({ id: i, orbitRadius: orbitRadii[i], angle, speed, r });
+    list.push({ id: i, orbitRadius, angle, speed, r });
   }
   return list;
 })();
@@ -588,9 +604,11 @@ function engageWarp(dir){
 
 // =============== Fizyk ===============
 function physicsStep(dt){
+  // czas gry
+  gameTime = (gameTime + dt * TIME_SCALE) % (24*3600);
   // aktualizacja orbit planet/stacji
   for(const st of stations){
-    st.angle += st.speed * dt;
+    st.angle += st.speed * dt * TIME_SCALE;
     st.x = SUN.x + Math.cos(st.angle) * st.orbitRadius;
     st.y = SUN.y + Math.sin(st.angle) * st.orbitRadius;
   }
@@ -909,6 +927,9 @@ function render(alpha){
 
   // Kamera
   const cam = { x: interpPos.x, y: interpPos.y };
+
+  // aktualizuj wyświetlanie czasu
+  gameTimeEl.textContent = formatGameTime(gameTime);
 
   // Czyścimy ekran
   ctx.clearRect(0,0,W,H);


### PR DESCRIPTION
## Summary
- Track a 24-hour in-game clock where each real minute equals one in-game hour
- Display current game time in the UI and advance planetary orbits using accelerated time
- Rework planetary distances and speeds using solar system ratios so inner planets orbit faster than outer ones

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac4fa72f1c8325b0e7ccbb1f682234