### PR TITLE
Add planet types and station orbits

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,10 +162,28 @@ function initStars(reset=false){
   if(reset){ starCells.clear(); }
 }
 
-// =============== Słońce i orbitujące planety/stacje ===============
+// =============== Słońce, planety i stacje ===============
 const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200 };
-const STATION_DATA = (() => {
-  const AU = [0.39, 0.72, 1.0, 1.52, 5.2, 9.58, 19.2, 30.05];
+
+const PLANET_TYPES = {
+  TERRAN: 'terran',
+  VOLCANIC: 'volcanic',
+  FROZEN: 'frozen',
+  GAS: 'gas',
+  BARREN: 'barren'
+};
+
+const PLANET_DATA = (() => {
+  const AU = [0.39, 0.72, 1.0, 1.52, 5.2, 9.58, 30.05];
+  const TYPES = [
+    PLANET_TYPES.VOLCANIC,
+    PLANET_TYPES.VOLCANIC,
+    PLANET_TYPES.TERRAN,
+    PLANET_TYPES.TERRAN,
+    PLANET_TYPES.BARREN,
+    PLANET_TYPES.GAS,
+    PLANET_TYPES.FROZEN
+  ];
   const BASE_ORBIT = 7000; // distance scale
   const list = [];
   for (let i = 0; i < AU.length; i++) {
@@ -174,20 +192,27 @@ const STATION_DATA = (() => {
     const angle = Math.random() * Math.PI * 2;
     const periodHours = 24 * Math.pow(au, 1.5); // Kepler scaling
     const speed = (2 * Math.PI) / (periodHours * 3600); // rad per game second
-    const r = 48 + Math.floor(Math.random() * 36);
-    list.push({ id: i, orbitRadius, angle, speed, r });
+    const r = (48 + Math.floor(Math.random() * 36)) * 3; // powiększone ~3×
+    list.push({ id: i, orbitRadius, angle, speed, r, type: TYPES[i], x: 0, y: 0 });
   }
   return list;
 })();
-let stations = STATION_DATA.map(p => ({
-  id: p.id,
-  orbitRadius: p.orbitRadius,
-  angle: p.angle,
-  speed: p.speed,
-  r: p.r,
-  x: SUN.x + Math.cos(p.angle) * p.orbitRadius,
-  y: SUN.y + Math.sin(p.angle) * p.orbitRadius,
-}));
+
+let planets = PLANET_DATA.map(p => {
+  p.x = SUN.x + Math.cos(p.angle) * p.orbitRadius;
+  p.y = SUN.y + Math.sin(p.angle) * p.orbitRadius;
+  return p;
+});
+
+let stations = planets.map(pl => {
+  const orbitRadius = pl.r + 300;
+  const angle = Math.random() * Math.PI * 2;
+  const periodHours = 12; // stacja okrąża planetę w 12h
+  const speed = (2 * Math.PI) / (periodHours * 3600);
+  const x = pl.x + Math.cos(angle) * orbitRadius;
+  const y = pl.y + Math.sin(angle) * orbitRadius;
+  return { id: pl.id, planet: pl, orbitRadius, angle, speed, r: 40, x, y };
+});
 
 const NPC_COUNT = 30;
 let npcs = [];
@@ -204,7 +229,7 @@ function initNPCs(){
   }
 }
 initNPCs();
-initPlanets3D(stations, SUN);
+initPlanets3D(planets, SUN);
 
 // =============== Bullets & effects ===============
 const bullets = [];
@@ -606,11 +631,16 @@ function engageWarp(dir){
 function physicsStep(dt){
   // czas gry
   gameTime = (gameTime + dt * TIME_SCALE) % (24*3600);
-  // aktualizacja orbit planet/stacji
+  // aktualizacja orbit planet i stacji
+  for(const pl of planets){
+    pl.angle += pl.speed * dt * TIME_SCALE;
+    pl.x = SUN.x + Math.cos(pl.angle) * pl.orbitRadius;
+    pl.y = SUN.y + Math.sin(pl.angle) * pl.orbitRadius;
+  }
   for(const st of stations){
     st.angle += st.speed * dt * TIME_SCALE;
-    st.x = SUN.x + Math.cos(st.angle) * st.orbitRadius;
-    st.y = SUN.y + Math.sin(st.angle) * st.orbitRadius;
+    st.x = st.planet.x + Math.cos(st.angle) * st.orbitRadius;
+    st.y = st.planet.y + Math.sin(st.angle) * st.orbitRadius;
   }
   // regen paliwa gdy nie warpuje
   if(warp.state!=='active') warp.fuel = clamp(warp.fuel + warp.regenRate*dt, 0, warp.fuelMax);

--- a/planet3d.js
+++ b/planet3d.js
@@ -148,8 +148,9 @@
 
   // ======= PLANETA =======
   class Planet3D {
-    constructor(size) {
+    constructor(size, type) {
       this.size = size;
+      this.type = type;
       // prywatny canvas 2D; będziemy wklejać bitmapę z sharedRenderer
       this.canvas = document.createElement("canvas");
       this.canvas.width = 256;
@@ -167,16 +168,27 @@
       this.camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
       this.camera.position.z = 3;
 
-      const dayTex = new THREE.CanvasTexture(tex.day); dayTex.wrapS = THREE.RepeatWrapping;
-      const nightTex = new THREE.CanvasTexture(tex.night); nightTex.wrapS = THREE.RepeatWrapping;
-
-      const mat = new THREE.MeshStandardMaterial({
-        map: dayTex,
-        emissive: new THREE.Color(0xffffff),
-        emissiveMap: nightTex,
-        emissiveIntensity: 0.8,
-        roughness: 1.0, metalness: 0.0,
-      });
+      let mat;
+      if (type === 'terran') {
+        const dayTex = new THREE.CanvasTexture(tex.day); dayTex.wrapS = THREE.RepeatWrapping;
+        const nightTex = new THREE.CanvasTexture(tex.night); nightTex.wrapS = THREE.RepeatWrapping;
+        mat = new THREE.MeshStandardMaterial({
+          map: dayTex,
+          emissive: new THREE.Color(0xffffff),
+          emissiveMap: nightTex,
+          emissiveIntensity: 0.8,
+          roughness: 1.0, metalness: 0.0,
+        });
+      } else {
+        const colors = {
+          volcanic: 0xaa5533,
+          frozen: 0x88ccff,
+          gas: 0xffd27f,
+          barren: 0x888888,
+        };
+        const color = colors[type] || 0x888888;
+        mat = new THREE.MeshStandardMaterial({ color });
+      }
 
       const geom = new THREE.SphereGeometry(1, 48, 32);
       this.mesh = new THREE.Mesh(geom, mat);
@@ -238,11 +250,11 @@
   }
 
   // ======= API =======
-  function initPlanets3D(stations, sunPos) {
+  function initPlanets3D(planetList, sunPos) {
     planets.length = 0;
-    for (const st of stations) {
-      const p = new Planet3D(st.r * 2.0); // mniejsze niż wcześniej, ale wyraźne "halo"
-      p.station = st;
+    for (const pl of planetList) {
+      const p = new Planet3D(pl.r * 2.0, pl.type); // mniejsze niż wcześniej, ale wyraźne "halo"
+      p.body = pl;
       planets.push(p);
     }
     sun = new Sun3D(sunPos.r * 2.5);
@@ -263,7 +275,7 @@
       ctx.drawImage(sun.canvas, sSun.x - sizeSun / 2, sSun.y - sizeSun / 2, sizeSun, sizeSun);
     }
     for (const p of planets) {
-      const s = worldToScreen(p.station.x, p.station.y, cam);
+      const s = worldToScreen(p.body.x, p.body.y, cam);
       const size = p.size * camera.zoom; // w Twojej grze camera jest globalna – zostawiam
       ctx.drawImage(p.canvas, s.x - size / 2, s.y - size / 2, size, size);
     }


### PR DESCRIPTION
## Summary
- Enlarge planets roughly threefold and introduce planet type metadata
- Position stations in planetary orbit and update orbit calculations
- Render planets with basic visuals for different types

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ac549d30ec83259c8be6bed1b3f409