### PR TITLE
Boost station route NPC traffic

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,16 +214,21 @@ let stations = planets.map(pl => {
   return { id: pl.id, planet: pl, orbitRadius, angle, speed, r: 40, x, y };
 });
 
-const NPC_COUNT = 30;
+const NPC_COUNT = 120;
 let npcs = [];
 function pickNextStation(npcId, lastStationId){ let idx = Math.floor(Math.random()*stations.length); if(stations.length>1 && stations[idx].id === lastStationId) idx = (idx+1)%stations.length; return stations[idx].id; }
 function initNPCs(){
   npcs = [];
   for(let i=0;i<NPC_COUNT;i++){
-    const st = stations[Math.floor(Math.random()*stations.length)];
-    npcs.push({ id:i, x: st.x + (Math.random()-0.5)*140, y: st.y + (Math.random()-0.5)*140,
+    const start = stations[Math.floor(Math.random()*stations.length)];
+    const targetId = pickNextStation(i, start.id);
+    const target = stations.find(s=>s.id===targetId);
+    const t = Math.random();
+    const x = start.x + (target.x - start.x) * t + (Math.random()-0.5)*60;
+    const y = start.y + (target.y - start.y) * t + (Math.random()-0.5)*60;
+    npcs.push({ id:i, x, y,
       vx:(Math.random()-0.5)*40, vy:(Math.random()-0.5)*40, angle:Math.random()*Math.PI*2,
-      target: pickNextStation(i, st.id), speed:70+Math.random()*90, radius:12+Math.random()*8,
+      target: targetId, speed:70+Math.random()*90, radius:12+Math.random()*8,
       hp:40+Math.random()*80, maxHp:80, color:`hsl(${Math.random()*360},70%,60%)`,
       dead:false, respawnTimer:0 });
   }
@@ -557,7 +562,20 @@ function npcShootingStep(dt){
 }
 function npcStep(dt){
   for(const npc of npcs){
-    if(npc.dead){ npc.respawnTimer -= dt; if(npc.respawnTimer<=0){ const s = stations[Math.floor(Math.random()*stations.length)]; npc.x = s.x + (Math.random()-0.5)*140; npc.y = s.y + (Math.random()-0.5)*140; npc.hp = npc.maxHp; npc.dead=false; npc.target = pickNextStation(npc.id, s.id); } continue; }
+    if(npc.dead){
+      npc.respawnTimer -= dt;
+      if(npc.respawnTimer<=0){
+        const start = stations[Math.floor(Math.random()*stations.length)];
+        const targetId = pickNextStation(npc.id, start.id);
+        const target = stations.find(s=>s.id===targetId);
+        const t = Math.random();
+        npc.x = start.x + (target.x - start.x)*t + (Math.random()-0.5)*60;
+        npc.y = start.y + (target.y - start.y)*t + (Math.random()-0.5)*60;
+        npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
+        npc.hp = npc.maxHp; npc.dead=false; npc.target = targetId;
+      }
+      continue;
+    }
     const st = stations.find(s=>s.id===npc.target);
     if(!st){ npc.target = pickNextStation(npc.id, -1); continue; }
     const to = { x: st.x - npc.x, y: st.y - npc.y }; const d = Math.hypot(to.x,to.y);


### PR DESCRIPTION
## Summary
- increase NPC count for denser traffic
- spawn and respawn NPCs along routes between stations for a livelier sector

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac5b045a348325b86b035ee71dddca