### PR TITLE
Increase NPC presence and add station fade-out

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ let stations = planets.map(pl => {
   return { id: pl.id, planet: pl, orbitRadius, angle, speed, r: 40, x, y };
 });
 
-const NPC_COUNT = 120;
+const NPC_COUNT = 200;
 let npcs = [];
 function pickNextStation(npcId, lastStationId){ let idx = Math.floor(Math.random()*stations.length); if(stations.length>1 && stations[idx].id === lastStationId) idx = (idx+1)%stations.length; return stations[idx].id; }
 function initNPCs(){
@@ -228,9 +228,9 @@ function initNPCs(){
     const y = start.y + (target.y - start.y) * t + (Math.random()-0.5)*60;
     npcs.push({ id:i, x, y,
       vx:(Math.random()-0.5)*40, vy:(Math.random()-0.5)*40, angle:Math.random()*Math.PI*2,
-      target: targetId, speed:70+Math.random()*90, radius:12+Math.random()*8,
+      target: targetId, speed:70+Math.random()*90, radius:16+Math.random()*8,
       hp:40+Math.random()*80, maxHp:80, color:`hsl(${Math.random()*360},70%,60%)`,
-      dead:false, respawnTimer:0 });
+      dead:false, respawnTimer:0, fade:1, docking:false, lastStation:start.id });
   }
 }
 initNPCs();
@@ -572,7 +572,22 @@ function npcStep(dt){
         npc.x = start.x + (target.x - start.x)*t + (Math.random()-0.5)*60;
         npc.y = start.y + (target.y - start.y)*t + (Math.random()-0.5)*60;
         npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
-        npc.hp = npc.maxHp; npc.dead=false; npc.target = targetId;
+        npc.hp = npc.maxHp; npc.dead=false; npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=start.id;
+      }
+      continue;
+    }
+    if(npc.docking){
+      const st = stations.find(s=>s.id===npc.lastStation);
+      if(st){ npc.x = st.x; npc.y = st.y; }
+      npc.fade -= dt / 0.6;
+      if(npc.fade <= 0 && st){
+        const targetId = pickNextStation(npc.id, npc.lastStation);
+        const target = stations.find(s=>s.id===targetId);
+        const t = Math.random();
+        npc.x = st.x + (target.x - st.x)*t + (Math.random()-0.5)*60;
+        npc.y = st.y + (target.y - st.y)*t + (Math.random()-0.5)*60;
+        npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
+        npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=st.id;
       }
       continue;
     }
@@ -587,7 +602,12 @@ function npcStep(dt){
     const toP = { x: ship.pos.x - npc.x, y: ship.pos.y - npc.y }; const dp = Math.hypot(toP.x,toP.y);
     if(dp < 120){ npc.vx -= (toP.x/dp) * 40*dt; npc.vy -= (toP.y/dp) * 40*dt; }
     npc.x += npc.vx*dt; npc.y += npc.vy*dt; npc.angle = Math.atan2(npc.vy||0, npc.vx||0);
-    if(d < 20) npc.target = pickNextStation(npc.id, st.id);
+    if(d < 20){
+      npc.docking = true;
+      npc.x = st.x; npc.y = st.y;
+      npc.vx = 0; npc.vy = 0;
+      npc.lastStation = st.id;
+    }
   }
 }
 
@@ -1054,7 +1074,9 @@ function render(alpha){
   for(const npc of npcs){
     if(npc.dead) continue;
     const s = worldToScreen(npc.x, npc.y, cam);
-    ctx.save(); ctx.translate(s.x,s.y); ctx.rotate(npc.angle);
+    ctx.save();
+    ctx.globalAlpha = npc.fade;
+    ctx.translate(s.x,s.y); ctx.rotate(npc.angle);
     ctx.fillStyle = npc.color;
     roundRectScreen(-npc.radius*camera.zoom, -npc.radius*camera.zoom,
                     npc.radius*2*camera.zoom, npc.radius*1.2*camera.zoom, 4*camera.zoom);


### PR DESCRIPTION
## Summary
- enlarge NPC size and raise overall count for busier station routes
- add docking fade-out so NPCs disappear into stations and respawn on new paths
- render NPCs with transparency during station docking

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_b_68ac61f30ff48325b8521e3a83742e4c