### PR TITLE
Fix planet orbit and rotation periods

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,8 @@ const PLANET_DATA = (() => {
     const au = AU[i];
     const orbitRadius = BASE_ORBIT * Math.pow(au, 0.6);
     const angle = Math.random() * Math.PI * 2;
-    const periodHours = 24 * Math.pow(au, 1.5); // Kepler scaling
+    // Orbital period scaled so that a planet at 1 AU orbits in 365 days
+    const periodHours = 24 * 365 * Math.pow(au, 1.5); // Kepler scaling
     const speed = (2 * Math.PI) / (periodHours * 3600); // rad per game second
     const r = (48 + Math.floor(Math.random() * 36)) * 3; // powiększone ~3×
     list.push({ id: i, orbitRadius, angle, speed, r, type: TYPES[i], x: 0, y: 0 });

--- a/planet3d.js
+++ b/planet3d.js
@@ -160,7 +160,8 @@
       this.scene = null;
       this.camera = null;
       this.mesh = null;
-      this.spin = 0.2 + Math.random() * 0.4;
+      // Rotate once every 24 in‑game minutes (24 real seconds)
+      this.spin = (2 * Math.PI) / (24 * 60); // rad per game second
 
       if (typeof THREE === "undefined") return;
 
@@ -201,7 +202,8 @@
 
     render(dt) {
       if (!this.scene || !this.camera) return;
-      this.mesh.rotation.y += this.spin * dt;
+      const ts = typeof TIME_SCALE !== 'undefined' ? TIME_SCALE : 60;
+      this.mesh.rotation.y += this.spin * dt * ts;
 
       const r = getSharedRenderer(this.canvas.width, this.canvas.height);
       if (!r) return;

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -412,6 +412,9 @@ const PLANET_FRAG = `// Terrain generation parameters
       this.material = buildPlanetMaterial();
       this.mesh = new THREE.Mesh(geom, this.material);
       this.scene.add(this.mesh);
+
+      // Rotate once every 24 in‑game minutes (24 real seconds)
+      this.spin = (2 * Math.PI) / (24 * 60); // rad per game second
     }
 
     // Update lightDir uniform from sector sun (0,0,0) toward this planet
@@ -428,6 +431,9 @@ const PLANET_FRAG = `// Terrain generation parameters
     render(dt) {
       if (!this.scene || !this.camera) return;
       this.updateLightDirection();
+
+      const ts = typeof TIME_SCALE !== 'undefined' ? TIME_SCALE : 60;
+      this.mesh.rotation.y += this.spin * dt * ts;
 
       const r = getSharedRenderer(this.canvas.width, this.canvas.height);
       if (!r) return;


### PR DESCRIPTION
## Summary
- Set planetary orbits to use 365-day periods instead of 24 hours
- Spin 3D planets once every 24 in-game minutes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac6654f7c0832598c49ee58fc675b5