### PR TITLE
Fix sun rendering by clearing WebGL background to transparent

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -141,6 +141,7 @@
     if (typeof THREE === "undefined") return null;
     if (!sharedRenderer) {
       sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
+      sharedRenderer.setClearColor(0x000000, 0);
     }
     sharedRenderer.setSize(width, height, false);
     return sharedRenderer;

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -327,6 +327,7 @@ const PLANET_FRAG = `// Terrain generation parameters
     if (typeof THREE === "undefined") return null;
     if (!sharedRenderer) {
       sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
+      sharedRenderer.setClearColor(0x000000, 0);
     }
     sharedRenderer.setSize(width, height, false);
     return sharedRenderer;


### PR DESCRIPTION
## Summary
- ensure shared WebGL renderer clears to transparent to draw sun correctly

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68ac6ab4b5a88325ab3a58e86c8ee37b