### PR TITLE
Render sun after planets to ensure visibility

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -141,6 +141,7 @@
     if (typeof THREE === "undefined") return null;
     if (!sharedRenderer) {
       sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
+      sharedRenderer.setClearColor(0x000000, 0);
     }
     sharedRenderer.setSize(width, height, false);
     return sharedRenderer;
@@ -271,15 +272,15 @@
   }
 
   function drawPlanets3D(ctx, cam) {
-    if (sun) {
-      const sSun = worldToScreen(sun.x, sun.y, cam);
-      const sizeSun = sun.size * camera.zoom;
-      ctx.drawImage(sun.canvas, sSun.x - sizeSun / 2, sSun.y - sizeSun / 2, sizeSun, sizeSun);
-    }
     for (const p of planets) {
       const s = worldToScreen(p.body.x, p.body.y, cam);
       const size = p.size * camera.zoom; // w Twojej grze camera jest globalna – zostawiam
       ctx.drawImage(p.canvas, s.x - size / 2, s.y - size / 2, size, size);
+    }
+    if (sun) {
+      const sSun = worldToScreen(sun.x, sun.y, cam);
+      const sizeSun = sun.size * camera.zoom;
+      ctx.drawImage(sun.canvas, sSun.x - sizeSun / 2, sSun.y - sizeSun / 2, sizeSun, sizeSun);
     }
   }
 

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -327,6 +327,7 @@ const PLANET_FRAG = `// Terrain generation parameters
     if (typeof THREE === "undefined") return null;
     if (!sharedRenderer) {
       sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
+      sharedRenderer.setClearColor(0x000000, 0);
     }
     sharedRenderer.setSize(width, height, false);
     return sharedRenderer;
@@ -565,17 +566,17 @@ const PLANET_FRAG = `// Terrain generation parameters
     for (const p of _planets) p.render(dt);
   }
   function drawPlanets3D(ctx, cam) {
-    if (sun) {
-      const ss = worldToScreen(sun.x, sun.y, cam);
-      const sizeS = sun.size * camera.zoom;
-      ctx.drawImage(sun.canvas, ss.x - sizeS/2, ss.y - sizeS/2, sizeS, sizeS);
+      for (const p of _planets) {
+        const s = worldToScreen(p.x, p.y, cam);
+        const size = p.size * camera.zoom;
+        ctx.drawImage(p.canvas, s.x - size/2, s.y - size/2, size, size);
+      }
+      if (sun) {
+        const ss = worldToScreen(sun.x, sun.y, cam);
+        const sizeS = sun.size * camera.zoom;
+        ctx.drawImage(sun.canvas, ss.x - sizeS/2, ss.y - sizeS/2, sizeS, sizeS);
+      }
     }
-    for (const p of _planets) {
-      const s = worldToScreen(p.x, p.y, cam);
-      const size = p.size * camera.zoom;
-      ctx.drawImage(p.canvas, s.x - size/2, s.y - size/2, size, size);
-    }
-  }
 
   function setPlanetsSunPos(x,y,z){
     SUN_POS = {x:x||0,y:y||0,z:z||0};


### PR DESCRIPTION
## Summary
- draw planets before sun so sun isn't hidden behind them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac6ab4b5a88325ab3a58e86c8ee37b