### PR TITLE
Cache renderer dimensions in 3D helpers

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -137,13 +137,19 @@
 
   // ======= WSPÓLNY RENDERER WEBGL (1 kontekst) =======
   let sharedRenderer = null;
+  let rendererWidth = 0;
+  let rendererHeight = 0;
   function getSharedRenderer(width, height) {
     if (typeof THREE === "undefined") return null;
     if (!sharedRenderer) {
       sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
       sharedRenderer.setClearColor(0x000000, 0);
     }
-    sharedRenderer.setSize(width, height, false);
+    if (width !== rendererWidth || height !== rendererHeight) {
+      sharedRenderer.setSize(width, height, false);
+      rendererWidth = width;
+      rendererHeight = height;
+    }
     return sharedRenderer;
   }
 

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -323,13 +323,19 @@ const PLANET_FRAG = `// Terrain generation parameters
 
   // === Shared WebGL renderer (one context) ===
   let sharedRenderer = null;
+  let rendererWidth = 0;
+  let rendererHeight = 0;
   function getSharedRenderer(width, height) {
     if (typeof THREE === "undefined") return null;
     if (!sharedRenderer) {
       sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
       sharedRenderer.setClearColor(0x000000, 0);
     }
-    sharedRenderer.setSize(width, height, false);
+    if (width !== rendererWidth || height !== rendererHeight) {
+      sharedRenderer.setSize(width, height, false);
+      rendererWidth = width;
+      rendererHeight = height;
+    }
     return sharedRenderer;
   }
 


### PR DESCRIPTION
## Summary
- track WebGL renderer dimensions in `planet3d.js` and `planet3d.proc.js`
- resize renderer only when width/height change

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac999837d08325a66050f7d9dddc26