### PR TITLE
Use cam zoom in drawPlanets3D

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -409,12 +409,12 @@
   function drawPlanets3D(ctx, cam) {
     for (const p of planets) {
       const s = worldToScreen(p.body.x, p.body.y, cam);
-      const size = p.size * camera.zoom; // w Twojej grze camera jest globalna – zostawiam
+      const size = p.size * cam.zoom;
       ctx.drawImage(p.canvas, s.x - size / 2, s.y - size / 2, size, size);
     }
     if (sun) {
       const sSun = worldToScreen(sun.x, sun.y, cam);
-      const sizeSun = sun.size * camera.zoom;
+      const sizeSun = sun.size * cam.zoom;
       ctx.drawImage(sun.canvas, sSun.x - sizeSun / 2, sSun.y - sizeSun / 2, sizeSun, sizeSun);
     }
   }

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -636,12 +636,12 @@ const PLANET_FRAG = `// Terrain generation parameters
   function drawPlanets3D(ctx, cam) {
       for (const p of _planets) {
         const s = worldToScreen(p.x, p.y, cam);
-        const size = p.size * camera.zoom;
+        const size = p.size * cam.zoom;
         ctx.drawImage(p.canvas, s.x - size/2, s.y - size/2, size, size);
       }
       if (sun) {
         const ss = worldToScreen(sun.x, sun.y, cam);
-        const sizeS = sun.size * camera.zoom;
+        const sizeS = sun.size * cam.zoom;
         ctx.drawImage(sun.canvas, ss.x - sizeS/2, ss.y - sizeS/2, sizeS, sizeS);
       }
     }


### PR DESCRIPTION
## Summary
- scale planet rendering using `cam.zoom`
- remove remaining global `camera` references from `drawPlanets3D`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68ac9997378c8325849d8964c3869c0a