### PR TITLE
Guard Sun3D.render from invalid dt

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -361,6 +361,7 @@
     }
 
     render(dt) {
+      dt = Number.isFinite(dt) ? dt : 0;
       if (!this.scene || !this.camera) return;
       this.time += dt;
       this.uniforms.uTime.value = this.time;

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -587,6 +587,7 @@ const PLANET_FRAG = `// Terrain generation parameters
     }
 
     render(dt) {
+      dt = Number.isFinite(dt) ? dt : 0;
       if (!this.scene || !this.camera) return;
       this.time += dt;
       this.uniforms.uTime.value = this.time;


### PR DESCRIPTION
## Summary
- Default `dt` to `0` when non-finite at the start of `Sun3D.render` in both development and production builds

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac99969ef883259db335a0506df4d2