### PR TITLE
Use cam zoom for rendering helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,8 +923,8 @@ function glowDot(ctx,x,y,r,color,alpha=1){ ctx.save(); ctx.globalAlpha=alpha; ct
 function plumeGradient(ctx,x,y,len,wide,c1,c2){ const g=ctx.createLinearGradient(x,y,x,y-len); g.addColorStop(0,c1); g.addColorStop(1,c2); ctx.fillStyle=g; ctx.beginPath(); ctx.moveTo(x-wide/2,y); ctx.quadraticCurveTo(x,y-len*0.5,x,y-len); ctx.quadraticCurveTo(x,y-len*0.5,x+wide/2,y); ctx.closePath(); ctx.fill(); }
 function drawBraided(state,ctx,o){ const L=120,A=20,t=state.t*2.5;ctx.lineWidth=3.2;ctx.lineCap='round'; for(let k=0;k<3;k++){ const phase=k*2.1;ctx.beginPath();ctx.strokeStyle=`hsla(${200+20*k},100%,75%,0.85)`; for(let y=0;y<=L;y+=4){const p=y/L;const x=o.x+Math.sin(-t+p*8+phase)*A*(1-p*0.8);ctx[p?'lineTo':'moveTo'](x,o.y-y);}ctx.stroke(); } plumeGradient(ctx,o.x,o.y,L,60,'rgba(100,180,255,0.25)','rgba(100,180,255,0)'); glowDot(ctx,o.x,o.y,10,'#dff',0.9); }
 function drawPhotonBeamLocal(alpha){ const L=200; ctx.save(); ctx.lineCap='round'; ctx.shadowBlur=28; ctx.shadowColor=`rgba(230,250,255,${0.95*alpha})`; ctx.strokeStyle=`rgba(255,255,255,${0.95*alpha})`; ctx.lineWidth=6; ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(0,-L*0.96); ctx.stroke(); ctx.restore(); plumeGradient(ctx,0,0,L,100,`rgba(160,210,255,${0.25*alpha})`,`rgba(160,210,255,0)`); for(let i=0;i<4;i++){ const phase=((vfxTime*0.8)+i*0.25)%1; const y=-phase*L; const r=20+40*(1-phase); ctx.strokeStyle=`rgba(200,240,255,${(1-phase)*alpha})`; ctx.lineWidth=2; ctx.beginPath(); ctx.arc(0,y,r,0,Math.PI*2); ctx.stroke(); } glowDot(ctx,0,0,12,'#fff',alpha); }
-function drawMainEngineVfx(pos, forward, cam){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(camera.zoom,camera.zoom); ctx.rotate(Math.atan2(-forward.x, forward.y)); ctx.globalCompositeOperation='lighter'; drawBraided({t:vfxTime},ctx,{x:0,y:0}); ctx.restore(); }
-function drawBoostBeam(pos, dir, cam, alpha){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(camera.zoom,camera.zoom); ctx.rotate(Math.atan2(-dir.x, dir.y)); ctx.globalCompositeOperation='lighter'; drawPhotonBeamLocal(alpha); ctx.restore(); }
+function drawMainEngineVfx(pos, forward, cam){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(cam.zoom,cam.zoom); ctx.rotate(Math.atan2(-forward.x, forward.y)); ctx.globalCompositeOperation='lighter'; drawBraided({t:vfxTime},ctx,{x:0,y:0}); ctx.restore(); }
+function drawBoostBeam(pos, dir, cam, alpha){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(cam.zoom,cam.zoom); ctx.rotate(Math.atan2(-dir.x, dir.y)); ctx.globalCompositeOperation='lighter'; drawPhotonBeamLocal(alpha); ctx.restore(); }
 
 // =============== Main loop ===============
 let lastTime = performance.now();
@@ -954,12 +954,12 @@ function loop(now){
 requestAnimationFrame(loop);
 
 // =============== Render ===============
-function worldToScreen(wx,wy,cam){ return { x: (wx - cam.x)*camera.zoom + W/2, y: (wy - cam.y)*camera.zoom + H/2 }; }
+function worldToScreen(wx,wy,cam){ return { x: (wx - cam.x)*cam.zoom + W/2, y: (wy - cam.y)*cam.zoom + H/2 }; }
 
 function drawStars(cam){
   // jak daleko poza ekran ładować komórki
-  const marginW = (W/2)/camera.zoom + 2000;
-  const marginH = (H/2)/camera.zoom + 2000;
+  const marginW = (W/2)/cam.zoom + 2000;
+  const marginH = (H/2)/cam.zoom + 2000;
   const minX = Math.floor((cam.x - marginW)/STAR_CELL);
   const maxX = Math.floor((cam.x + marginW)/STAR_CELL);
   const minY = Math.floor((cam.y - marginH)/STAR_CELL);
@@ -969,8 +969,8 @@ function drawStars(cam){
     for(let ix=minX; ix<=maxX; ix++){
       const cell = getCell(ix,iy);
       for(const s of cell.stars){
-        const sx = (s.x - cam.x) * camera.zoom + W/2;
-        const sy = (s.y - cam.y) * camera.zoom + H/2;
+        const sx = (s.x - cam.x) * cam.zoom + W/2;
+        const sy = (s.y - cam.y) * cam.zoom + H/2;
         if(sx < -50 || sx > W+50 || sy < -50 || sy > H+50) continue;
 
         if(warp.state==='active'){
@@ -1003,7 +1003,7 @@ function render(alpha){
   const interpTurretAngle = interpAngleShort(prevState.turretAngle, ship.turret.angle, alpha);
 
   // Kamera
-  const cam = { x: interpPos.x, y: interpPos.y };
+  const cam = { x: interpPos.x, y: interpPos.y, zoom: camera.zoom };
 
   // aktualizuj wyświetlanie czasu
   gameTimeEl.textContent = formatGameTime(gameTime);

--- a/planet3d.js
+++ b/planet3d.js
@@ -409,12 +409,12 @@
   function drawPlanets3D(ctx, cam) {
     for (const p of planets) {
       const s = worldToScreen(p.body.x, p.body.y, cam);
-      const size = p.size * camera.zoom; // w Twojej grze camera jest globalna – zostawiam
+      const size = p.size * cam.zoom; // w Twojej grze camera jest globalna – zostawiam
       ctx.drawImage(p.canvas, s.x - size / 2, s.y - size / 2, size, size);
     }
     if (sun) {
       const sSun = worldToScreen(sun.x, sun.y, cam);
-      const sizeSun = sun.size * camera.zoom;
+      const sizeSun = sun.size * cam.zoom;
       ctx.drawImage(sun.canvas, sSun.x - sizeSun / 2, sSun.y - sizeSun / 2, sizeSun, sizeSun);
     }
   }

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -636,12 +636,12 @@ const PLANET_FRAG = `// Terrain generation parameters
   function drawPlanets3D(ctx, cam) {
       for (const p of _planets) {
         const s = worldToScreen(p.x, p.y, cam);
-        const size = p.size * camera.zoom;
+        const size = p.size * cam.zoom;
         ctx.drawImage(p.canvas, s.x - size/2, s.y - size/2, size, size);
       }
       if (sun) {
         const ss = worldToScreen(sun.x, sun.y, cam);
-        const sizeS = sun.size * camera.zoom;
+        const sizeS = sun.size * cam.zoom;
         ctx.drawImage(sun.canvas, ss.x - sizeS/2, ss.y - sizeS/2, sizeS, sizeS);
       }
     }


### PR DESCRIPTION
## Summary
- Use cam.zoom in worldToScreen and star/engine VFX helpers
- Pass zoom through cam object for planet rendering
- Scale 3D planet draw calls with cam-specific zoom

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac99b2dd3c83259180f8e32c7b084c