### PR TITLE
Fix 3D planets rendering by using camera zoom

### DIFF
--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -643,12 +643,12 @@ const PLANET_FRAG = `// Terrain generation parameters
   function drawPlanets3D(ctx, cam) {
       for (const p of _planets) {
         const s = worldToScreen(p.x, p.y, cam);
-        const size = p.size * cam.zoom;
+        const size = p.size * camera.zoom;
         ctx.drawImage(p.canvas, s.x - size/2, s.y - size/2, size, size);
       }
       if (sun) {
         const ss = worldToScreen(sun.x, sun.y, cam);
-        const sizeS = sun.size * cam.zoom;
+        const sizeS = sun.size * camera.zoom;
         ctx.drawImage(sun.canvas, ss.x - sizeS/2, ss.y - sizeS/2, sizeS, sizeS);
       }
     }


### PR DESCRIPTION
## Summary
- Use global `camera.zoom` when drawing 3D planets and sun to avoid NaN sizes that stopped rendering.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ac9ae68bd08325b9f4c580e894a1c8