### PR TITLE
Fix planets shader tangent and postprocessing fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
     <div style="margin-top:6px"><small>Gwiazdy są proceduralne w całej galaktyce. Silnik: niebieski exhaust + krótki ślad przy ruchu.</small></div>
   </div>
 <canvas id="c"></canvas>
-<!-- Mapowanie modułów -->
 <script type="importmap">
 {
   "imports": {
@@ -30,48 +29,14 @@
   }
 }
 </script>
-
-<!-- Wstrzyknięcie THREE i dodatków do window dla skryptów niemieszkających w ESM -->
 <script type="module">
-  import * as THREE from 'three';
-  import { EffectComposer }  from 'three/addons/postprocessing/EffectComposer.js';
-  import { RenderPass }      from 'three/addons/postprocessing/RenderPass.js';
-  import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-
-  // 👇 to jest kluczowe dla planet3d*.js, które oczekują globali:
+  import * as THREE from "three";
+  import { EffectComposer }  from "three/addons/postprocessing/EffectComposer.js";
+  import { RenderPass }      from "three/addons/postprocessing/RenderPass.js";
+  import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
   window.THREE = THREE;
   window.EffectComposer  = EffectComposer;
   window.RenderPass      = RenderPass;
-  window.UnrealBloomPass = UnrealBloomPass;
-</script>
-
-<!-- dopiero teraz ładujemy logikę 2D/kanwy -->
-<script src="planet3d.proc.js"></script>
-
-<script type="importmap">
-{
-  "imports": {
-    "three": "./node_modules/three/build/three.module.js",
-    "three/addons/": "./node_modules/three/examples/jsm/"
-  }
-}
-</script>
-
-<script type="module">
-  import { EffectComposer }  from 'three/addons/postprocessing/EffectComposer.js';
-  import { RenderPass }      from 'three/addons/postprocessing/RenderPass.js';
-  import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-  // udostępnienie globalnie dla planet3d.proc.js
-  window.EffectComposer  = EffectComposer;
-  window.RenderPass      = RenderPass;
-  window.UnrealBloomPass = UnrealBloomPass;
-</script>
-<script type="module">
-  import { EffectComposer } from './node_modules/three/examples/jsm/postprocessing/EffectComposer.js';
-  import { RenderPass } from './node_modules/three/examples/jsm/postprocessing/RenderPass.js';
-  import { UnrealBloomPass } from './node_modules/three/examples/jsm/postprocessing/UnrealBloomPass.js';
-  window.EffectComposer = EffectComposer;
-  window.RenderPass = RenderPass;
   window.UnrealBloomPass = UnrealBloomPass;
 </script>
 <script src="planet3d.proc.js"></script>


### PR DESCRIPTION
## Summary
- remove leftover conflict markup and three.min.js script from index
- add importmap & module loader to expose THREE and postprocessing utilities globally
- rebuild planet shader without tangent attribute and add EffectComposer fallback when postprocessing isn't available

## Testing
- `rg -n "fragTangent = T" planet3d.proc.js`
- `rg -n "hasPP" planet3d.proc.js`
- `rg -n "window\.THREE = THREE" index.html`
- `npm start --silent &` *(dev server starts at http://localhost:8080 then terminated)*

------
https://chatgpt.com/codex/tasks/task_b_68aca99e925c8325b9ef0af2cdaac045