### PR TITLE
Fix planet and sun rendering by delaying 3D init

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,10 @@ function initNPCs(){
   }
 }
 initNPCs();
-initPlanets3D(planets, SUN);
+// Ensure Three.js modules are loaded before initializing 3D objects
+window.addEventListener('DOMContentLoaded', () => {
+  initPlanets3D(planets, SUN);
+});
 
 // =============== Bullets & effects ===============
 const bullets = [];


### PR DESCRIPTION
## Summary
- Initialize planets and sun only after DOMContentLoaded so Three.js globals are ready

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68acaaea2bf0832598f6c14c2174f4ea