### PR TITLE
Expand and fade sector map

### DIFF
--- a/index.html
+++ b/index.html
@@ -1302,14 +1302,14 @@ function render(alpha){
 }
 
 function drawSectorMap(){
-  const mapW = 400;
+  const mapW = 600;
   const mapH = Math.round(mapW * WORLD.h / WORLD.w);
   const x0 = (W - mapW) / 2;
   const y0 = (H - mapH) / 2;
   ctx.save();
-  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillStyle = 'rgba(0,0,0,0.4)';
   ctx.fillRect(0,0,W,H);
-  ctx.fillStyle = '#1a1a1a';
+  ctx.fillStyle = 'rgba(26,26,26,0.8)';
   ctx.fillRect(x0, y0, mapW, mapH);
   ctx.strokeStyle = '#dfe7ff';
   ctx.lineWidth = 2;


### PR DESCRIPTION
## Summary
- Enlarge in-game sector map and dim background less to emphasize map details.
- Render map panel with semi-transparency for a clearer view of underlying action.

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_b_68acb44201bc8325bc0c5c2bec39e58f