### PR TITLE
Limit scan highlight to nearby enemies

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,6 +337,7 @@ let lockedTargets = [];
 let highlightedEnemies = [];
 let highlightTimer = 0;
 const HIGHLIGHT_TIME = 3;
+const HIGHLIGHT_RANGE = 2000;
 const radarPings = [];
 const scanWaves = [];
 const scanArrows = [];
@@ -345,7 +346,7 @@ function triggerScanWave(){
   const wave = {x:ship.pos.x,y:ship.pos.y,r:0,speed:SCAN_VFX_SPEED,max:SCAN_RANGE,hit:new Set()};
   scanWaves.push(wave);
   scanArrows.length = 0;
-  highlightedEnemies = npcs.filter(n=>!n.dead);
+  highlightedEnemies = npcs.filter(n=>!n.dead && Math.hypot(n.x - ship.pos.x, n.y - ship.pos.y) <= HIGHLIGHT_RANGE);
   highlightTimer = HIGHLIGHT_TIME;
   for(const st of stations){
     const dist = Math.hypot(st.x - ship.pos.x, st.y - ship.pos.y);


### PR DESCRIPTION
## Summary
- Highlight only enemies within 2000 units when triggering a scan
- Introduce `HIGHLIGHT_RANGE` constant to control scan highlight distance

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68acb5f822688325b430e40352d812ee