### PR TITLE
Fix asteroid belt rendering scale

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -490,17 +490,17 @@
   function drawPlanets3D(ctx, cam) {
     if (asteroidBelt && sun) {
       const sB = worldToScreen(sun.x, sun.y, cam);
-      const sizeB = asteroidBelt.size * cam.zoom;
+      const sizeB = asteroidBelt.size * camera.zoom;
       ctx.drawImage(asteroidBelt.canvas, sB.x - sizeB / 2, sB.y - sizeB / 2, sizeB, sizeB);
     }
     for (const p of planets) {
       const s = worldToScreen(p.body.x, p.body.y, cam);
-      const size = p.size * cam.zoom;
+      const size = p.size * camera.zoom;
       ctx.drawImage(p.canvas, s.x - size / 2, s.y - size / 2, size, size);
     }
     if (sun) {
       const sSun = worldToScreen(sun.x, sun.y, cam);
-      const sizeSun = sun.size * cam.zoom;
+      const sizeSun = sun.size * camera.zoom;
       ctx.drawImage(sun.canvas, sSun.x - sizeSun / 2, sSun.y - sizeSun / 2, sizeSun, sizeSun);
     }
   }


### PR DESCRIPTION
## Summary
- use global `camera.zoom` to size asteroid belt and planets in 3D overlay

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68acbf0d3bb48325aed22d4dc0d4fd38