### PR TITLE
Keep escort guards in formation with freighters

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@ function initNPCs(){
   npcs = [];
   let npcId = 0, groupCounter = 0;
   const desiredCount = 1000;
+  const ESCORT_RADIUS = 80;
   function spawnNPC(type, start, targetId, group){
     if(npcs.length >= desiredCount) return null;
     const cfg = NPC_TYPES[type];
@@ -281,7 +282,7 @@ function initNPCs(){
       if(!escort) continue;
       escort.leader = leader.id;
       escort.orbitAngle = angle;
-      escort.orbitRadius = leader.radius + 40;
+      escort.orbitRadius = leader.radius + ESCORT_RADIUS;
       escort.x = leader.x + Math.cos(angle) * escort.orbitRadius;
       escort.y = leader.y + Math.sin(angle) * escort.orbitRadius;
     }
@@ -719,7 +720,6 @@ function npcStep(dt){
     if(npc.leader != null){
       const leader = npcs.find(n=>n.id===npc.leader && !n.dead);
       if(leader){
-        npc.orbitAngle += 0.5 * dt;
         targetPos = {
           x: leader.x + Math.cos(npc.orbitAngle) * npc.orbitRadius,
           y: leader.y + Math.sin(npc.orbitAngle) * npc.orbitRadius


### PR DESCRIPTION
## Summary
- Keep escort ships at a fixed distance from their freighter instead of orbiting
- Set escort formation radius to 80 units around the leader

## Testing
- `npm test` *(fails: Missing script: "test")*

## PR Checklist
- [x] Brak nowych globali (poza parametrami w obrębie 3D).
- [x] Jedna instancja `WebGLRenderer` (współdzielona).
- [x] Bez alokacji w pętli (`animate`/`render`).
- [ ] FPS bez spadków (profiluj `performance.now()`).
- [x] Warstwa grywalna (2D) nietknięta.


------
https://chatgpt.com/codex/tasks/task_b_68acc1d88d0c83258573778a0b2ec179