### PR TITLE
feat: add shader engine exhaust

### DIFF
--- a/index.html
+++ b/index.html
@@ -1059,11 +1059,43 @@ function physicsStep(dt){
 }
 
 // ======= Efekty VFX =======
+const engineVFX = (typeof THREE!=="undefined" && typeof getSharedRenderer==="function") ? (()=>{
+  const canvas = document.createElement('canvas');
+  canvas.width = 60; canvas.height = 100;
+  const ctx2d = canvas.getContext('2d');
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera(-100,100,100,-100,-1000,1000);
+  const geo = new THREE.PlaneGeometry(30,50,1,1);
+  const mat = new THREE.ShaderMaterial({
+    transparent:true, depthWrite:false, blending:THREE.AdditiveBlending,
+    uniforms:{
+      uTime:{value:0},
+      uColor:{value:new THREE.Color(0xffffff)},
+      uIntensity:{value:3.0},
+      uLength:{value:1.0},
+    },
+    vertexShader:`varying vec2 vUv;void main(){vUv=uv;gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.0);}`,
+    fragmentShader:`precision highp float;varying vec2 vUv;uniform float uTime;uniform vec3 uColor;uniform float uIntensity;uniform float uLength;void main(){float y=vUv.y;float x=abs(vUv.x-0.5);float width=mix(0.55,0.18,y);float cross=smoothstep(1.0,0.0,x/width);float flick=0.88+0.12*sin(uTime*48.0);float along=(1.0-y);along*=smoothstep(0.0,0.12,y);along*=smoothstep(0.85,0.35,y*uLength);float a=cross*along*flick;vec3 col=uColor*a*uIntensity*2.0;gl_FragColor=vec4(col,a);}`
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.position.set(0,-5,0);
+  scene.add(mesh);
+  return {canvas, ctx2d, mat, camera, scene, render(time){
+    const r = getSharedRenderer(canvas.width, canvas.height);
+    if(!r) return;
+    mat.uniforms.uTime.value = time;
+    mat.uniforms.uLength.value = 0.95 + 0.05*Math.sin(time*1.5);
+    mat.uniforms.uIntensity.value = 2.8 + 0.3*Math.sin(time*1.8);
+    r.render(scene,camera);
+    ctx2d.clearRect(0,0,canvas.width,canvas.height);
+    ctx2d.drawImage(r.domElement,0,0,canvas.width,canvas.height);
+  }};
+})() : null;
 function glowDot(ctx,x,y,r,color,alpha=1){ ctx.save(); ctx.globalAlpha=alpha; ctx.shadowBlur=r*1.6; ctx.shadowColor=color; ctx.fillStyle=color; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill(); ctx.restore(); }
 function plumeGradient(ctx,x,y,len,wide,c1,c2){ const g=ctx.createLinearGradient(x,y,x,y-len); g.addColorStop(0,c1); g.addColorStop(1,c2); ctx.fillStyle=g; ctx.beginPath(); ctx.moveTo(x-wide/2,y); ctx.quadraticCurveTo(x,y-len*0.5,x,y-len); ctx.quadraticCurveTo(x,y-len*0.5,x+wide/2,y); ctx.closePath(); ctx.fill(); }
 function drawBraided(state,ctx,o){ const L=120,A=20,t=state.t*2.5;ctx.lineWidth=3.2;ctx.lineCap='round'; for(let k=0;k<3;k++){ const phase=k*2.1;ctx.beginPath();ctx.strokeStyle=`hsla(${200+20*k},100%,75%,0.85)`; for(let y=0;y<=L;y+=4){const p=y/L;const x=o.x+Math.sin(-t+p*8+phase)*A*(1-p*0.8);ctx[p?'lineTo':'moveTo'](x,o.y-y);}ctx.stroke(); } plumeGradient(ctx,o.x,o.y,L,60,'rgba(100,180,255,0.25)','rgba(100,180,255,0)'); glowDot(ctx,o.x,o.y,10,'#dff',0.9); }
 function drawPhotonBeamLocal(alpha){ const L=200; ctx.save(); ctx.lineCap='round'; ctx.shadowBlur=28; ctx.shadowColor=`rgba(230,250,255,${0.95*alpha})`; ctx.strokeStyle=`rgba(255,255,255,${0.95*alpha})`; ctx.lineWidth=6; ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(0,-L*0.96); ctx.stroke(); ctx.restore(); plumeGradient(ctx,0,0,L,100,`rgba(160,210,255,${0.25*alpha})`,`rgba(160,210,255,0)`); for(let i=0;i<4;i++){ const phase=((vfxTime*0.8)+i*0.25)%1; const y=-phase*L; const r=20+40*(1-phase); ctx.strokeStyle=`rgba(200,240,255,${(1-phase)*alpha})`; ctx.lineWidth=2; ctx.beginPath(); ctx.arc(0,y,r,0,Math.PI*2); ctx.stroke(); } glowDot(ctx,0,0,12,'#fff',alpha); }
-function drawMainEngineVfx(pos, forward, cam){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(camera.zoom,camera.zoom); ctx.rotate(Math.atan2(-forward.x, forward.y)); ctx.globalCompositeOperation='lighter'; drawBraided({t:vfxTime},ctx,{x:0,y:0}); ctx.restore(); }
+function drawMainEngineVfx(pos, forward, cam){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(camera.zoom,camera.zoom); ctx.rotate(Math.atan2(-forward.x, forward.y)); ctx.globalCompositeOperation='lighter'; if(engineVFX){ engineVFX.render(vfxTime); const w=engineVFX.canvas.width, h=engineVFX.canvas.height; ctx.drawImage(engineVFX.canvas,-w/2,0,w,h); } else { drawBraided({t:vfxTime},ctx,{x:0,y:0}); } ctx.restore(); }
 function drawBoostBeam(pos, dir, cam, alpha){ const s=worldToScreen(pos.x,pos.y,cam); ctx.save(); ctx.translate(s.x,s.y); ctx.scale(camera.zoom,camera.zoom); ctx.rotate(Math.atan2(-dir.x, dir.y)); ctx.globalCompositeOperation='lighter'; drawPhotonBeamLocal(alpha); ctx.restore(); }
 
 // =============== Main loop ===============


### PR DESCRIPTION
## Summary
- integrate shader-based engine exhaust using shared Three.js renderer
- render exhaust to offscreen canvas and blend into main canvas

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ad7b1b7a58832587cb5d1568c6727a