### PR TITLE
Enable three.js engine exhaust effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1082,7 +1082,6 @@ const engineVFX = (typeof THREE!=="undefined" && typeof getSharedRenderer==="fun
 })() : null;
 function glowDot(ctx,x,y,r,color,alpha=1){ ctx.save(); ctx.globalAlpha=alpha; ctx.shadowBlur=r*1.6; ctx.shadowColor=color; ctx.fillStyle=color; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill(); ctx.restore(); }
 function plumeGradient(ctx,x,y,len,wide,c1,c2){ const g=ctx.createLinearGradient(x,y,x,y-len); g.addColorStop(0,c1); g.addColorStop(1,c2); ctx.fillStyle=g; ctx.beginPath(); ctx.moveTo(x-wide/2,y); ctx.quadraticCurveTo(x,y-len*0.5,x,y-len); ctx.quadraticCurveTo(x,y-len*0.5,x+wide/2,y); ctx.closePath(); ctx.fill(); }
-function drawBraided(state,ctx,o){ const L=120,A=20,t=state.t*2.5;ctx.lineWidth=3.2;ctx.lineCap='round'; for(let k=0;k<3;k++){ const phase=k*2.1;ctx.beginPath();ctx.strokeStyle=`hsla(${200+20*k},100%,75%,0.85)`; for(let y=0;y<=L;y+=4){const p=y/L;const x=o.x+Math.sin(-t+p*8+phase)*A*(1-p*0.8);ctx[p?'lineTo':'moveTo'](x,o.y-y);}ctx.stroke(); } plumeGradient(ctx,o.x,o.y,L,60,'rgba(100,180,255,0.25)','rgba(100,180,255,0)'); glowDot(ctx,o.x,o.y,10,'#dff',0.9); }
 function drawPhotonBeamLocal(alpha){ const L=200; ctx.save(); ctx.lineCap='round'; ctx.shadowBlur=28; ctx.shadowColor=`rgba(230,250,255,${0.95*alpha})`; ctx.strokeStyle=`rgba(255,255,255,${0.95*alpha})`; ctx.lineWidth=6; ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(0,-L*0.96); ctx.stroke(); ctx.restore(); plumeGradient(ctx,0,0,L,100,`rgba(160,210,255,${0.25*alpha})`,`rgba(160,210,255,0)`); for(let i=0;i<4;i++){ const phase=((vfxTime*0.8)+i*0.25)%1; const y=-phase*L; const r=20+40*(1-phase); ctx.strokeStyle=`rgba(200,240,255,${(1-phase)*alpha})`; ctx.lineWidth=2; ctx.beginPath(); ctx.arc(0,y,r,0,Math.PI*2); ctx.stroke(); } glowDot(ctx,0,0,12,'#fff',alpha); }
 
 function drawMainEngineVfx(pos, forward, cam) {
@@ -1097,8 +1096,6 @@ function drawMainEngineVfx(pos, forward, cam) {
     engineVFX.render(vfxTime);
     const w = engineVFX.canvas.width, h = engineVFX.canvas.height;
     ctx.drawImage(engineVFX.canvas, -w / 2, 0, w, h);
-  } else {
-    drawBraided({ t: vfxTime }, ctx, { x: 0, y: 0 });
   }
 
   ctx.restore();

--- a/planet3d.js
+++ b/planet3d.js
@@ -533,4 +533,5 @@
   window.initPlanets3D = initPlanets3D;
   window.updatePlanets3D = updatePlanets3D;
   window.drawPlanets3D = drawPlanets3D;
+  window.getSharedRenderer = getSharedRenderer;
 })();

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -837,4 +837,5 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
   window.setPlanetsSunPos = setPlanetsSunPos;
   window.updatePlanets3D = updatePlanets3D;
   window.drawPlanets3D = drawPlanets3D;
+  window.getSharedRenderer = getSharedRenderer;
 })();


### PR DESCRIPTION
## Summary
- expose getSharedRenderer globally so other effects can reuse the shared WebGL renderer
- remove 2D fallback flame and render main engine exhaust with three.js needles

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ad8e156e948325bdfceb6ad285e49f