### PR TITLE
Fix depth handling for engine exhaust VFX

### DIFF
--- a/Engineeffects.js
+++ b/Engineeffects.js
@@ -19,6 +19,7 @@ function makeNeedleMaterial({
   return new THREE.ShaderMaterial({
     transparent: true,
     depthWrite: false,
+    depthTest: false,           // ważne przy współdzielonym rendererze
     blending: THREE.AdditiveBlending,
     uniforms: {
       uTime:       { value: 0 },

--- a/index.html
+++ b/index.html
@@ -1075,7 +1075,11 @@ function getEngineVFX() {
     canvas.width = 80; canvas.height = 120;
     const ctx2d = canvas.getContext("2d");
     const scene = new THREE.Scene();
+    scene.background = null;              // transparent
+
     const camera = new THREE.OrthographicCamera(-40, 40, 40, -80, -1000, 1000);
+    camera.position.z = 10;               // oddal kamerę od z=0
+    camera.lookAt(0, 0, 0);
 
     // UWAGA: bierzemy z window – moduł może się zainicjalizować dopiero po parsowaniu
     const exhaust = window.createShortNeedleExhaust({ /* opcjonalne tweaki */ });
@@ -1087,6 +1091,11 @@ function getEngineVFX() {
       render(time) {
         const r = getSharedRenderer(canvas.width, canvas.height);
         if (!r) return;
+
+        // ważne przy reuse renderera między scenami
+        r.setClearColor(0x000000, 0);   // przezroczyste tło (alfa=0)
+        r.clearDepth();                 // czyści bufor głębokości po planetach
+
         exhaust.update(time);
         r.render(scene, camera);
         ctx2d.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- Disable depth testing in engine exhaust needle material
- Use transparent scene and adjust orthographic camera for engine VFX
- Clear shared renderer depth and set transparent clear color before rendering

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ad9acd30c4832581ee628049f9e120