### PR TITLE
Fix engine exhaust visibility and renderer clearing

### DIFF
--- a/Engineeffects.js
+++ b/Engineeffects.js
@@ -21,6 +21,8 @@ function makeNeedleMaterial({
     depthWrite: false,
     depthTest: false,           // ważne przy współdzielonym rendererze
     blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,    // oglądany z obu stron
+    toneMapped: false,         // bez mapowania tonów (np. ACES)
     uniforms: {
       uTime:       { value: 0 },
       uColorA:     { value: new THREE.Color(colorA) },

--- a/index.html
+++ b/index.html
@@ -1094,7 +1094,7 @@ function getEngineVFX() {
 
         // ważne przy reuse renderera między scenami
         r.setClearColor(0x000000, 0);   // przezroczyste tło (alfa=0)
-        r.clearDepth();                 // czyści bufor głębokości po planetach
+        r.clear(true, true, false);     // kolor + depth (stencil niepotrzebny)
 
         exhaust.update(time);
         r.render(scene, camera);


### PR DESCRIPTION
## Summary
- Ensure shader material draws engine exhaust from both sides and bypasses tone mapping
- Clear shared renderer's color and depth before rendering engine VFX

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ad9d4d6fbc832584f89f9af4caa879