### PR TITLE
feat: add warp gate travel and npc queuing

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,50 @@ let stations = planets.map(pl => {
   return { id: pl.id, planet: pl, orbitRadius, angle, speed, r: 40, x, y };
 });
 
+// Warp routes between stations
+let warpRoutes = {};
+function initWarpRoutes(){
+  warpRoutes = {};
+  for(const from of stations){
+    for(const to of stations){
+      if(from.id === to.id) continue;
+      const sx = from.x + (to.x - from.x) * 0.2;
+      const sy = from.y + (to.y - from.y) * 0.2;
+      const ex = from.x + (to.x - from.x) * 0.8;
+      const ey = from.y + (to.y - from.y) * 0.8;
+      warpRoutes[from.id + '-' + to.id] = {
+        from: from.id,
+        to: to.id,
+        start: { x: sx, y: sy, queue: [], busy:false },
+        end: { x: ex, y: ey }
+      };
+    }
+  }
+}
+
+function updateWarpRoutes(){
+  for(const key in warpRoutes){
+    const route = warpRoutes[key];
+    const from = stations.find(s=>s.id===route.from);
+    const to = stations.find(s=>s.id===route.to);
+    if(!from || !to) continue;
+    route.start.x = from.x + (to.x - from.x) * 0.2;
+    route.start.y = from.y + (to.y - from.y) * 0.2;
+    route.end.x = from.x + (to.x - from.x) * 0.8;
+    route.end.y = from.y + (to.y - from.y) * 0.8;
+    for(const npc of route.start.queue){
+      const gv = { x: route.start.x - from.x, y: route.start.y - from.y };
+      const gd = Math.hypot(gv.x, gv.y) || 1;
+      const perp = { x: -gv.y/gd, y: gv.x/gd };
+      const offset = npc.lane ? 20 : -20;
+      npc.x = route.start.x + perp.x*offset;
+      npc.y = route.start.y + perp.y*offset;
+    }
+  }
+}
+function getWarpRoute(fromId, toId){ return warpRoutes[fromId + '-' + toId]; }
+initWarpRoutes();
+
 let npcs = [];
 function pickNextStation(npcId, lastStationId){ let idx = Math.floor(Math.random()*stations.length); if(stations.length>1 && stations[idx].id === lastStationId) idx = (idx+1)%stations.length; return stations[idx].id; }
 const NPC_TYPES = {
@@ -262,13 +306,15 @@ function initNPCs(){
     const t = Math.random();
     const x = start.x + (target.x - start.x) * t + (Math.random()-0.5)*60;
     const y = start.y + (target.y - start.y) * t + (Math.random()-0.5)*60;
+    const route = getWarpRoute(start.id, targetId);
     const npc = { id:npcId++, type, group,
       x, y,
       vx:(Math.random()-0.5)*40, vy:(Math.random()-0.5)*40, angle:Math.random()*Math.PI*2,
       target: targetId, speed:cfg.speed, radius:cfg.radius,
       hp:cfg.hp, maxHp:cfg.hp, color:cfg.color, weapon:cfg.weapon,
       dead:false, respawnTimer:0, fade:1, docking:false, lastStation:start.id,
-      leader:null, orbitAngle:0, orbitRadius:0 };
+      leader:null, orbitAngle:0, orbitRadius:0,
+      warpRoute: route, phase: 'toGate', lane: Math.floor(Math.random()*2) };
     npcs.push(npc);
     return npc;
   }
@@ -702,6 +748,7 @@ function npcStep(dt){
         npc.y = start.y + (target.y - start.y)*t + (Math.random()-0.5)*60;
         npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
         npc.hp = npc.maxHp; npc.dead=false; npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=start.id;
+        npc.warpRoute = getWarpRoute(start.id, targetId); npc.phase = 'toGate'; npc.lane = Math.floor(Math.random()*2);
       }
       continue;
     }
@@ -717,7 +764,47 @@ function npcStep(dt){
         npc.y = st.y + (target.y - st.y)*t + (Math.random()-0.5)*60;
         npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
         npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=st.id;
+        npc.warpRoute = getWarpRoute(st.id, targetId); npc.phase = 'toGate'; npc.lane = Math.floor(Math.random()*2);
       }
+      continue;
+    }
+    if(npc.phase === 'warping'){
+      npc.warpTimer -= dt;
+      if(npc.warpTimer <= 0){
+        npc.phase = 'toStation';
+        npc.x = npc.warpRoute.end.x; npc.y = npc.warpRoute.end.y;
+        npc.vx = 0; npc.vy = 0;
+        npc.warpRoute.start.busy = false;
+      }
+      continue;
+    }
+    if(npc.phase === 'toGate'){
+      const gate = npc.warpRoute.start;
+      const start = stations.find(s=>s.id===npc.lastStation);
+      const gv = { x: gate.x - start.x, y: gate.y - start.y };
+      const gd = Math.hypot(gv.x, gv.y) || 1;
+      const perp = { x: -gv.y/gd, y: gv.x/gd };
+      const offset = npc.lane ? 20 : -20;
+      const targetPos = { x: gate.x + perp.x*offset, y: gate.y + perp.y*offset };
+      const to = { x: targetPos.x - npc.x, y: targetPos.y - npc.y };
+      const d = Math.hypot(to.x,to.y);
+      if(d < 5){
+        if(!gate.queue.includes(npc)) gate.queue.push(npc);
+        npc.vx = 0; npc.vy = 0;
+        if(gate.queue[0] === npc && !gate.busy){
+          gate.busy = true;
+          gate.queue.shift();
+          npc.phase = 'warping';
+          npc.warpTimer = 0.5;
+          npc.x = gate.x; npc.y = gate.y;
+        }
+        continue;
+      }
+      const dir = { x: to.x/d, y: to.y/d };
+      const desiredV = { x: dir.x*npc.speed, y: dir.y*npc.speed };
+      npc.vx += (desiredV.x - (npc.vx||0)) * clamp(1.5*dt,0,1);
+      npc.vy += (desiredV.y - (npc.vy||0)) * clamp(1.5*dt,0,1);
+      npc.x += npc.vx*dt; npc.y += npc.vy*dt; npc.angle = Math.atan2(npc.vy||0, npc.vx||0);
       continue;
     }
     let targetPos, st = null;
@@ -734,8 +821,17 @@ function npcStep(dt){
     }
     if(!targetPos){
       st = stations.find(s=>s.id===npc.target);
-      if(!st){ npc.target = pickNextStation(npc.id, -1); continue; }
-      targetPos = { x: st.x, y: st.y };
+      if(!st){ npc.target = pickNextStation(npc.id, -1); npc.warpRoute = getWarpRoute(npc.lastStation, npc.target); npc.phase='toGate'; continue; }
+      if(npc.phase === 'toStation'){
+        const gate = npc.warpRoute.end;
+        const gv = { x: st.x - gate.x, y: st.y - gate.y };
+        const gd = Math.hypot(gv.x, gv.y) || 1;
+        const perp = { x: -gv.y/gd, y: gv.x/gd };
+        const offset = npc.lane ? 20 : -20;
+        targetPos = { x: st.x + perp.x*offset, y: st.y + perp.y*offset };
+      } else {
+        targetPos = { x: st.x, y: st.y };
+      }
     }
     const to = { x: targetPos.x - npc.x, y: targetPos.y - npc.y };
     const d = Math.hypot(to.x,to.y);
@@ -747,7 +843,8 @@ function npcStep(dt){
     const toP = { x: ship.pos.x - npc.x, y: ship.pos.y - npc.y }; const dp = Math.hypot(toP.x,toP.y);
     if(dp < 120){ npc.vx -= (toP.x/dp) * 40*dt; npc.vy -= (toP.y/dp) * 40*dt; }
     npc.x += npc.vx*dt; npc.y += npc.vy*dt; npc.angle = Math.atan2(npc.vy||0, npc.vx||0);
-    if(npc.leader == null && st && d < 20){
+    const distToStation = st ? Math.hypot(st.x - npc.x, st.y - npc.y) : Infinity;
+    if(npc.leader == null && st && distToStation < 20){
       npc.docking = true;
       npc.x = st.x; npc.y = st.y;
       npc.vx = 0; npc.vy = 0;
@@ -825,6 +922,7 @@ function physicsStep(dt){
     st.x = st.planet.x + Math.cos(st.angle) * st.orbitRadius;
     st.y = st.planet.y + Math.sin(st.angle) * st.orbitRadius;
   }
+  updateWarpRoutes();
   // regen paliwa gdy nie warpuje
   if(warp.state!=='active') warp.fuel = clamp(warp.fuel + warp.regenRate*dt, 0, warp.fuelMax);
   if(boost.state==='idle' && boost.effectTime<=0) boost.fuel = clamp(boost.fuel + boost.regenRate*dt, 0, boost.fuelMax);
@@ -1298,6 +1396,21 @@ function render(alpha){
     ctx.strokeStyle = 'rgba(120,180,255,0.15)';
     ctx.lineWidth = 2;
     ctx.beginPath(); ctx.moveTo(s1.x, s1.y); ctx.lineTo(s2.x, s2.y); ctx.stroke();
+  }
+
+  // Warp gates
+  for(const key in warpRoutes){
+    const route = warpRoutes[key];
+    const s1 = worldToScreen(route.start.x, route.start.y, cam);
+    const s2 = worldToScreen(route.end.x, route.end.y, cam);
+    const r = 10 * camera.zoom;
+    ctx.fillStyle = '#88aaff';
+    ctx.beginPath(); ctx.arc(s1.x, s1.y, r, 0, Math.PI*2); ctx.fill();
+    ctx.beginPath(); ctx.arc(s2.x, s2.y, r, 0, Math.PI*2); ctx.fill();
+    ctx.strokeStyle = '#335dff';
+    ctx.lineWidth = 2 * camera.zoom;
+    ctx.beginPath(); ctx.arc(s1.x, s1.y, r, 0, Math.PI*2); ctx.stroke();
+    ctx.beginPath(); ctx.arc(s2.x, s2.y, r, 0, Math.PI*2); ctx.stroke();
   }
 
   // Stacje


### PR DESCRIPTION
## Summary
- update warp gate positions each frame so gates follow moving stations
- render larger warp gate markers and keep queued NPCs aligned with gates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68adba09a74c832599a0d2fca03b3910