### PR TITLE
feat: add warp gate queuing and travel

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,11 +248,16 @@ function initWarpRoutes(){
       const sy = from.y + (to.y - from.y) * 0.2;
       const ex = from.x + (to.x - from.x) * 0.8;
       const ey = from.y + (to.y - from.y) * 0.8;
+      const dx = ex - sx;
+      const dy = ey - sy;
+      const dist = Math.hypot(dx, dy) || 1;
       warpRoutes[from.id + '-' + to.id] = {
         from: from.id,
         to: to.id,
-        start: { x: sx, y: sy, queue: [], busy:false },
-        end: { x: ex, y: ey }
+        start: { x: sx, y: sy, queues: [[], []] },
+        end: { x: ex, y: ey },
+        dir: { x: dx / dist, y: dy / dist },
+        length: dist
       };
     }
   }
@@ -281,14 +286,12 @@ function initNPCs(){
   function spawnNPC(type, start, targetId, group){
     if(npcs.length >= desiredCount) return null;
     const cfg = NPC_TYPES[type];
-    const target = stations.find(s=>s.id===targetId);
-    const t = Math.random();
-    const x = start.x + (target.x - start.x) * t + (Math.random()-0.5)*60;
-    const y = start.y + (target.y - start.y) * t + (Math.random()-0.5)*60;
+    const x = start.x + (Math.random()-0.5)*40;
+    const y = start.y + (Math.random()-0.5)*40;
     const route = getWarpRoute(start.id, targetId);
     const npc = { id:npcId++, type, group,
       x, y,
-      vx:(Math.random()-0.5)*40, vy:(Math.random()-0.5)*40, angle:Math.random()*Math.PI*2,
+      vx:0, vy:0, angle:Math.random()*Math.PI*2,
       target: targetId, speed:cfg.speed, radius:cfg.radius,
       hp:cfg.hp, maxHp:cfg.hp, color:cfg.color, weapon:cfg.weapon,
       dead:false, respawnTimer:0, fade:1, docking:false, lastStation:start.id,
@@ -721,11 +724,9 @@ function npcStep(dt){
       if(npc.respawnTimer<=0){
         const start = stations[Math.floor(Math.random()*stations.length)];
         const targetId = pickNextStation(npc.id, start.id);
-        const target = stations.find(s=>s.id===targetId);
-        const t = Math.random();
-        npc.x = start.x + (target.x - start.x)*t + (Math.random()-0.5)*60;
-        npc.y = start.y + (target.y - start.y)*t + (Math.random()-0.5)*60;
-        npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
+        npc.x = start.x + (Math.random()-0.5)*40;
+        npc.y = start.y + (Math.random()-0.5)*40;
+        npc.vx = 0; npc.vy = 0;
         npc.hp = npc.maxHp; npc.dead=false; npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=start.id;
         npc.warpRoute = getWarpRoute(start.id, targetId); npc.phase = 'toGate'; npc.lane = Math.floor(Math.random()*2);
       }
@@ -737,23 +738,22 @@ function npcStep(dt){
       npc.fade -= dt / 0.6;
       if(npc.fade <= 0 && st){
         const targetId = pickNextStation(npc.id, npc.lastStation);
-        const target = stations.find(s=>s.id===targetId);
-        const t = Math.random();
-        npc.x = st.x + (target.x - st.x)*t + (Math.random()-0.5)*60;
-        npc.y = st.y + (target.y - st.y)*t + (Math.random()-0.5)*60;
-        npc.vx = (Math.random()-0.5)*40; npc.vy = (Math.random()-0.5)*40;
+        npc.x = st.x + (Math.random()-0.5)*40;
+        npc.y = st.y + (Math.random()-0.5)*40;
+        npc.vx = 0; npc.vy = 0;
         npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=st.id;
         npc.warpRoute = getWarpRoute(st.id, targetId); npc.phase = 'toGate'; npc.lane = Math.floor(Math.random()*2);
       }
       continue;
     }
     if(npc.phase === 'warping'){
-      npc.warpTimer -= dt;
-      if(npc.warpTimer <= 0){
+      npc.x += npc.vx*dt; npc.y += npc.vy*dt;
+      npc.angle = Math.atan2(npc.vy||0, npc.vx||0);
+      const route = npc.warpRoute;
+      const traveled = (npc.x - route.start.x) * route.dir.x + (npc.y - route.start.y) * route.dir.y;
+      if(traveled >= route.length){
         npc.phase = 'toStation';
-        npc.x = npc.warpRoute.end.x; npc.y = npc.warpRoute.end.y;
-        npc.vx = 0; npc.vy = 0;
-        npc.warpRoute.start.busy = false;
+        npc.x = route.end.x; npc.y = route.end.y;
       }
       continue;
     }
@@ -762,21 +762,32 @@ function npcStep(dt){
       const start = stations.find(s=>s.id===npc.lastStation);
       const gv = { x: gate.x - start.x, y: gate.y - start.y };
       const gd = Math.hypot(gv.x, gv.y) || 1;
-      const perp = { x: -gv.y/gd, y: gv.x/gd };
-      const offset = npc.lane ? 20 : -20;
-      const targetPos = { x: gate.x + perp.x*offset, y: gate.y + perp.y*offset };
+      const dirToGate = { x: gv.x/gd, y: gv.y/gd };
+      const perp = { x: -dirToGate.y, y: dirToGate.x };
+      const laneOffset = npc.lane ? 20 : -20;
+      const gatePos = { x: gate.x + perp.x*laneOffset, y: gate.y + perp.y*laneOffset };
+      const queue = gate.queues[npc.lane];
+      let idx = queue.indexOf(npc);
+      if(idx === -1){ queue.push(npc); idx = queue.length-1; }
+      const spacing = 30;
+      const targetPos = {
+        x: gatePos.x - dirToGate.x * idx * spacing,
+        y: gatePos.y - dirToGate.y * idx * spacing
+      };
+      const distGate = Math.hypot(npc.x - gatePos.x, npc.y - gatePos.y);
+      if(idx === 0 && distGate < 5){
+        queue.shift();
+        npc.phase = 'warping';
+        npc.vx = npc.warpRoute.dir.x * 4000;
+        npc.vy = npc.warpRoute.dir.y * 4000;
+        npc.x = gatePos.x;
+        npc.y = gatePos.y;
+        continue;
+      }
       const to = { x: targetPos.x - npc.x, y: targetPos.y - npc.y };
-      const d = Math.hypot(to.x,to.y);
-      if(d < 5){
-        if(!gate.queue.includes(npc)) gate.queue.push(npc);
+      const d = Math.hypot(to.x, to.y);
+      if(d < 1){
         npc.vx = 0; npc.vy = 0;
-        if(gate.queue[0] === npc && !gate.busy){
-          gate.busy = true;
-          gate.queue.shift();
-          npc.phase = 'warping';
-          npc.warpTimer = 0.5;
-          npc.x = gate.x; npc.y = gate.y;
-        }
         continue;
       }
       const dir = { x: to.x/d, y: to.y/d };
@@ -1438,11 +1449,20 @@ function render(alpha){
   // Warp gates
   for(const key in warpRoutes){
     const route = warpRoutes[key];
+    const perp = { x: -route.dir.y, y: route.dir.x };
+    const w = 6*camera.zoom;
     const s1 = worldToScreen(route.start.x, route.start.y, cam);
     const s2 = worldToScreen(route.end.x, route.end.y, cam);
-    ctx.fillStyle = '#88aaff';
-    ctx.beginPath(); ctx.arc(s1.x, s1.y, 6*camera.zoom, 0, Math.PI*2); ctx.fill();
-    ctx.beginPath(); ctx.arc(s2.x, s2.y, 6*camera.zoom, 0, Math.PI*2); ctx.fill();
+    ctx.strokeStyle = '#88aaff';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(s1.x - perp.x*w, s1.y - perp.y*w);
+    ctx.lineTo(s1.x + perp.x*w, s1.y + perp.y*w);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(s2.x - perp.x*w, s2.y - perp.y*w);
+    ctx.lineTo(s2.x + perp.x*w, s2.y + perp.y*w);
+    ctx.stroke();
   }
 
   // Stacje


### PR DESCRIPTION
## Summary
- add per-lane warp gate queues with direction data
- spawn NPCs at stations and accelerate them through warp at 4000 speed
- draw warp gates as simple lines instead of circles

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68adf5755bec8325899c2c4752c736bf