### PR TITLE
Space planets evenly

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ const PLANET_TYPES = {
 };
 
 const PLANET_DATA = (() => {
-  const AU = [0.39, 0.72, 1.0, 1.52, 5.2, 9.58, 30.05];
+  const NUM_PLANETS = 7;
   const TYPES = [
     PLANET_TYPES.VOLCANIC,
     PLANET_TYPES.VOLCANIC,
@@ -206,12 +206,12 @@ const PLANET_DATA = (() => {
     PLANET_TYPES.GAS,
     PLANET_TYPES.FROZEN
   ];
-  const BASE_ORBIT = 7000; // distance scale
+  const BASE_ORBIT = 7000; // stała odległość między orbitami
   const list = [];
-  for (let i = 0; i < AU.length; i++) {
-    const au = AU[i];
-    const orbitRadius = BASE_ORBIT * Math.pow(au, 0.6);
+  for (let i = 0; i < NUM_PLANETS; i++) {
+    const orbitRadius = BASE_ORBIT * (i + 1);
     const angle = Math.random() * Math.PI * 2;
+    const au = i + 1; // jednostka do skalowania prędkości orbitalnej
     // Orbital period scaled so that a planet at 1 AU orbits in 365 days
     const periodHours = 24 * 365 * Math.pow(au, 1.5); // Kepler scaling
     const speed = (2 * Math.PI) / (periodHours * 3600); // rad per game second


### PR DESCRIPTION
## Summary
- evenly space planetary orbits to avoid inner clustering
- preserve asteroid belt placement so last three planets orbit beyond it

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b0b86a8b9883259e4fcb66a983949f