### PR TITLE
Shorten main gun barrel length by half

### DIFF
--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,7 @@ function render(alpha){
   }
 
   // wieżyczki podwójne z recoilem
-  const baseW = 16, baseH = 24, barrelLen = Math.max(22, Math.round(ship.h * 0.24)), barrelH = 6, gap = 10;
+  const baseW = 16, baseH = 24, barrelLen = Math.max(22, Math.round(ship.h * 0.24)) / 2, barrelH = 6, gap = 10;
   const turrets = [
     { t: ship.turret, ang: interpTurretAngle },
     { t: ship.turret2, ang: interpTurretAngle2 }


### PR DESCRIPTION
## Summary
- shorten the player's rail gun barrels to half their previous length for a more compact look

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b0bffd1dc48325bf79e9385b533524