### PR TITLE
Fix freeze after firing special weapon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1659,7 +1659,7 @@ function render(alpha){
 
   // Particles (za statkiem)
   for(const p of particles){
-    if(p.flash) continue;
+    if(p.flash || p.beam) continue;
     const s = worldToScreen(p.pos.x, p.pos.y, cam);
     const t = clamp(1 - p.age/p.life, 0, 1);
     ctx.globalAlpha = t;


### PR DESCRIPTION
## Summary
- avoid referencing beam particles during particle rendering to prevent crash after firing super weapon

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b201df55288325a0d51910fead0245