### PR TITLE
feat: add engine exhaust color temperature and bloom controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1460,6 +1460,9 @@ function getEngineVFX() {
 
       exhaust.setThrottle(throttle);
       exhaust.setWarpBoost(Math.max(boostAmp, warpAmp));
+      // Możesz dopasować temperaturę i bloom z poziomu opcji (D3):
+      exhaust.setColorTemp(OPTIONS.vfx.colorTempK);
+      exhaust.setBloomGain(OPTIONS.vfx.bloomGain);
 
       exhaust.update(time);
       r.render(scene, camera);


### PR DESCRIPTION
## Summary
- add adjustable color temperature and bloom gain to engine exhaust VFX
- introduce idle pulse and temperature-driven coloration
- expose VFX tuning through OPTIONS in the render loop

## Testing
- `npm test` *(fails: Missing script "test" as no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_b_68b46b85943c8325a5ab4d6849862179