### PR TITLE
Allow toggling station UI with Enter

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,9 +556,14 @@ function stationUnderCursor(){
 }
 
 window.addEventListener('keydown', (e)=>{
-  if(e.code==='Enter' && !stationUI.open){
-    const s = stationUnderCursor();
-    if(s){ stationUI.open = true; stationUI.station = s; stationUI.tab='upgrades'; e.preventDefault(); }
+  if(e.code==='Enter'){
+    e.preventDefault();
+    if(!stationUI.open){
+      const s = stationUnderCursor();
+      if(s){ stationUI.open = true; stationUI.station = s; stationUI.tab='upgrades'; }
+    } else {
+      stationUI.open=false; stationUI.station=null;
+    }
   }
   if(stationUI.open){
     if(e.code==='Escape'){ stationUI.open=false; stationUI.station=null; }


### PR DESCRIPTION
## Summary
- let Enter close an open station panel
- centralize Enter handling for station UI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_b_68b472c4dc348325a8b82241303ef71f