### PR TITLE
feat: expand stations with vfx and docking ports

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,8 @@ let planets = PLANET_DATA.map(p => {
   return p;
 });
 
+const STATION_STYLES = ['ringGate','hexHub','triRing','solarPetals','shipyard','tradeSpindle'];
+
 let stations = planets.map(pl => {
   const orbitRadius = pl.r + 300;
   const angle = Math.random() * Math.PI * 2;
@@ -275,7 +277,16 @@ let stations = planets.map(pl => {
   const speed = (2 * Math.PI) / (periodHours * 3600);
   const x = pl.x + Math.cos(angle) * orbitRadius;
   const y = pl.y + Math.sin(angle) * orbitRadius;
-  return { id: pl.id, planet: pl, orbitRadius, angle, speed, r: 40, x, y };
+  const r = 60;
+  const portOffset = r + 40;
+  const ports = [
+    {x: portOffset, y: 0},
+    {x: 0, y: portOffset},
+    {x: -portOffset, y: 0},
+    {x: 0, y: -portOffset}
+  ];
+  const style = STATION_STYLES[Math.floor(Math.random()*STATION_STYLES.length)];
+  return { id: pl.id, planet: pl, orbitRadius, angle, speed, r, x, y, ports, style };
 });
 
 // oznacz stacje wewnątrz pasa asteroid
@@ -432,9 +443,12 @@ function initNPCs(){
   function spawnNPC(type, start, targetId, group){
     if(npcs.length >= desiredCount) return null;
     const cfg = NPC_TYPES[type];
-    const x = start.x + (Math.random()-0.5)*40;
-    const y = start.y + (Math.random()-0.5)*40;
+    const startPort = Math.floor(Math.random()*start.ports.length);
+    const spawnPos = stationPortWorld(start, startPort);
+    const x = spawnPos.x + (Math.random()-0.5)*10;
+    const y = spawnPos.y + (Math.random()-0.5)*10;
     const target = stations.find(s=>s.id===targetId);
+    const dockPort = target ? Math.floor(Math.random()*target.ports.length) : 0;
     const route = (target && start.inner === target.inner) ? getWarpRoute(start.id, targetId) : null;
     const npc = { id:npcId++, type, group,
       x, y,
@@ -445,7 +459,8 @@ function initNPCs(){
       leader:null, orbitAngle:0, orbitRadius:0,
       warpRoute: route,
       phase: route?'toGate':'direct',
-      lane: route?Math.floor(Math.random()*2):0 };
+      lane: route?Math.floor(Math.random()*2):0,
+      dockPort };
     npcs.push(npc);
     return npc;
   }
@@ -713,7 +728,16 @@ function startMercenaryMission(){
   const angle = Math.random() * Math.PI * 2;
   const x = SUN.x + Math.cos(angle) * beltRadius;
   const y = SUN.y + Math.sin(angle) * beltRadius;
-  const station = { id:'PIR', x, y, r:80, hp:10000, maxHp:10000, static:true, mission:true };
+  const r = 100;
+  const portOffset = r + 40;
+  const ports = [
+    {x: portOffset, y: 0},
+    {x: 0, y: portOffset},
+    {x: -portOffset, y: 0},
+    {x: 0, y: -portOffset}
+  ];
+  const station = { id:'PIR', x, y, r, hp:10000, maxHp:10000, static:true, mission:true,
+    ports, style: STATION_STYLES[Math.floor(Math.random()*STATION_STYLES.length)] };
   stations.push(station);
   mercMission = { station, npcsSpawned:false };
   toast('Misja najemnik rozpoczęta');
@@ -1232,11 +1256,14 @@ function npcStep(dt){
         const group = stations.filter(s=>s.inner === base.inner);
         const start = group[Math.floor(Math.random()*group.length)];
         const targetId = pickNextStation(start.id, npc.type);
-        npc.x = start.x + (Math.random()-0.5)*40;
-        npc.y = start.y + (Math.random()-0.5)*40;
+        const startPort = Math.floor(Math.random()*start.ports.length);
+        const spawnPos = stationPortWorld(start, startPort);
+        npc.x = spawnPos.x;
+        npc.y = spawnPos.y;
         npc.vx = 0; npc.vy = 0;
         npc.hp = npc.maxHp; npc.dead=false; npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=start.id;
         const target = stations.find(s=>s.id===targetId);
+        npc.dockPort = target ? Math.floor(Math.random()*target.ports.length) : 0;
         if(target && start.inner === target.inner){
           const route = getWarpRoute(start.id, targetId);
           if(route){ npc.warpRoute = route; npc.phase = 'toGate'; npc.lane = Math.floor(Math.random()*2); }
@@ -1249,15 +1276,21 @@ function npcStep(dt){
     }
     if(npc.docking){
       const st = stations.find(s=>s.id===npc.lastStation);
-      if(st){ npc.x = st.x; npc.y = st.y; }
+      if(st){
+        const portPos = stationPortWorld(st, npc.dockPort || 0);
+        npc.x = portPos.x; npc.y = portPos.y;
+      }
       npc.fade -= dt / 0.6;
       if(npc.fade <= 0 && st){
         const targetId = pickNextStation(npc.lastStation, npc.type);
-        npc.x = st.x + (Math.random()-0.5)*40;
-        npc.y = st.y + (Math.random()-0.5)*40;
+        const startPort = Math.floor(Math.random()*st.ports.length);
+        const spawnPos = stationPortWorld(st, startPort);
+        npc.x = spawnPos.x;
+        npc.y = spawnPos.y;
         npc.vx = 0; npc.vy = 0;
         npc.target = targetId; npc.fade = 1; npc.docking=false; npc.lastStation=st.id;
         const target = stations.find(s=>s.id===targetId);
+        npc.dockPort = target ? Math.floor(Math.random()*target.ports.length) : 0;
         if(target && st.inner === target.inner){
           const route = getWarpRoute(st.id, targetId);
           if(route){ npc.warpRoute = route; npc.phase = 'toGate'; npc.lane = Math.floor(Math.random()*2); }
@@ -1355,13 +1388,8 @@ function npcStep(dt){
         }
         continue;
       }
-      if(npc.phase === 'toStation'){
-        const gate = npc.warpRoute.end;
-        const gv = { x: st.x - gate.x, y: st.y - gate.y };
-        const gd = Math.hypot(gv.x, gv.y) || 1;
-        const perp = { x: -gv.y/gd, y: gv.x/gd };
-        const offset = npc.lane ? 20 : -20;
-        targetPos = { x: st.x + perp.x*offset, y: st.y + perp.y*offset };
+      if(npc.phase === 'toStation' || npc.phase === 'direct'){
+        targetPos = stationPortWorld(st, npc.dockPort || 0);
       } else {
         targetPos = { x: st.x, y: st.y };
       }
@@ -1376,10 +1404,11 @@ function npcStep(dt){
     const toP = { x: ship.pos.x - npc.x, y: ship.pos.y - npc.y }; const dp = Math.hypot(toP.x,toP.y);
     if(dp < 120){ npc.vx -= (toP.x/dp) * 40*dt; npc.vy -= (toP.y/dp) * 40*dt; }
     npc.x += npc.vx*dt; npc.y += npc.vy*dt; npc.angle = Math.atan2(npc.vy||0, npc.vx||0);
-    const distToStation = st ? Math.hypot(st.x - npc.x, st.y - npc.y) : Infinity;
+    const portPos = st ? stationPortWorld(st, npc.dockPort || 0) : null;
+    const distToStation = portPos ? Math.hypot(portPos.x - npc.x, portPos.y - npc.y) : Infinity;
     if(npc.leader == null && st && distToStation < 20){
       npc.docking = true;
-      npc.x = st.x; npc.y = st.y;
+      npc.x = portPos.x; npc.y = portPos.y;
       npc.vx = 0; npc.vy = 0;
       npc.lastStation = st.id;
     }
@@ -1918,6 +1947,68 @@ function loop(now){
 // =============== Render ===============
 function worldToScreen(wx,wy,cam){ return { x: (wx - cam.x)*camera.zoom + W/2, y: (wy - cam.y)*camera.zoom + H/2 }; }
 
+function stationPortWorld(st, idx){
+  const off = st.ports[idx % st.ports.length];
+  return { x: st.x + off.x, y: st.y + off.y };
+}
+
+function glowCircle(ctx, x, y, r, color){
+  ctx.save();
+  ctx.shadowColor = color;
+  ctx.shadowBlur = r*0.5;
+  ctx.fillStyle = color;
+  ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill();
+  ctx.restore();
+}
+
+function drawStationVFX(ctx, st, x, y, r, t){
+  ctx.save();
+  ctx.translate(x, y);
+  switch(st.style){
+    case 'ringGate':
+      ctx.strokeStyle = '#273447';
+      ctx.lineWidth = r*0.2;
+      ctx.beginPath(); ctx.arc(0,0,r,0,Math.PI*2); ctx.stroke();
+      ctx.save(); ctx.rotate(t*0.6);
+      for(let i=0;i<6;i++){ ctx.rotate(Math.PI/3); glowCircle(ctx, r*0.6, 0, r*0.12, '#6dd6ff'); }
+      ctx.restore();
+      glowCircle(ctx,0,0,r*0.3,'#6dd6ff');
+      break;
+    case 'hexHub':
+      ctx.strokeStyle = '#273447';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      for(let i=0;i<6;i++){ const a=i*Math.PI/3; const px=Math.cos(a)*r*0.6; const py=Math.sin(a)*r*0.6; if(i===0) ctx.moveTo(px,py); else ctx.lineTo(px,py); }
+      ctx.closePath(); ctx.stroke();
+      break;
+    case 'triRing':
+      ctx.strokeStyle = '#273447'; ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.arc(0,0,r*0.9,0,Math.PI*2); ctx.stroke();
+      ctx.beginPath(); ctx.arc(0,0,r*0.6,0,Math.PI*2); ctx.stroke();
+      ctx.beginPath(); ctx.arc(0,0,r*0.3,0,Math.PI*2); ctx.stroke();
+      break;
+    case 'solarPetals':
+      ctx.save(); ctx.rotate(t*0.5);
+      for(let i=0;i<8;i++){ ctx.rotate(Math.PI/4); ctx.fillStyle='#274a7d'; ctx.fillRect(r*0.3,-r*0.1,r*0.4,r*0.2); }
+      ctx.restore();
+      glowCircle(ctx,0,0,r*0.25,'#8fd0ff');
+      break;
+    case 'shipyard':
+      ctx.save();
+      for(let i=0;i<4;i++){ ctx.rotate(Math.PI/2); ctx.fillStyle='#344a74'; ctx.fillRect(r*0.2,-r*0.05,r*0.8,r*0.1); }
+      ctx.restore();
+      break;
+    case 'tradeSpindle':
+      ctx.fillStyle='#3b517d'; ctx.fillRect(-r*0.1,-r,r*0.2,r*2);
+      for(let i=-3;i<=3;i++){ ctx.fillStyle='#6ea0ff'; ctx.fillRect(r*0.3, i*r*0.2 - r*0.05, r*0.3, r*0.1); ctx.fillRect(-r*0.6, i*r*0.2 - r*0.05, r*0.3, r*0.1); }
+      break;
+  }
+  ctx.restore();
+  ctx.strokeStyle = 'rgba(175,210,255,0.12)';
+  ctx.lineWidth = 2;
+  ctx.beginPath(); ctx.arc(x, y, r*1.05, 0, Math.PI*2); ctx.stroke();
+}
+
 function drawStars(cam){
   // jak daleko poza ekran ładować komórki
   const marginW = (W/2)/camera.zoom + 2000;
@@ -2047,10 +2138,13 @@ function render(alpha){
   for(const st of stations){
     const s = worldToScreen(st.x, st.y, cam);
     const rr = st.r * camera.zoom;
-    ctx.fillStyle = '#273447';
-    roundRectScreen(s.x - rr, s.y - rr*0.6, rr*2, rr*1.2, 6*camera.zoom); ctx.fill();
-    ctx.strokeStyle = 'rgba(175,210,255,0.12)'; ctx.lineWidth = 2;
-    ctx.beginPath(); ctx.arc(s.x, s.y, rr*1.05, 0, Math.PI*2); ctx.stroke();
+    drawStationVFX(ctx, st, s.x, s.y, rr, gameTime);
+    for(let i=0;i<st.ports.length;i++){
+      const pw = stationPortWorld(st, i);
+      const ps = worldToScreen(pw.x, pw.y, cam);
+      ctx.fillStyle = '#60a5fa';
+      ctx.beginPath(); ctx.arc(ps.x, ps.y, 4*camera.zoom, 0, Math.PI*2); ctx.fill();
+    }
     ctx.fillStyle = '#dfe7ff'; ctx.font = `${12*camera.zoom}px monospace`;
     ctx.fillText('ST'+st.id, s.x - rr*0.35, s.y + 4*camera.zoom);
   }


### PR DESCRIPTION
## Summary
- enlarge stations and assign random animated VFX styles
- add four docking ports per station and render their markers
- adjust NPC spawn and docking logic to use station ports

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b4a9a032508325a9560a3d4837bc85