### PR TITLE
Fix fractal noise normalization stability

### DIFF
--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -91,10 +91,15 @@ const NOISE_FUNCTIONS = `const float PI = 3.14159265;
       float P = period;  // Period for current octave
 
       for(int i = 0; i < octaves; i++) {
+          max_amp += a;
           n += a * simplex3(v / P);
           a *= persistence;
-          max_amp += a;
           P /= lacunarity;
+      }
+
+      // Avoid division by zero if octaves <= 0 or persistence killed amplitude
+      if (max_amp <= 0.0) {
+          return 0.0;
       }
 
       // Normalize noise between [0.0, amplitude]


### PR DESCRIPTION
## Summary
- correct the fractal noise normalization to include the amplitude actually used for each octave
- guard against division by zero when persistence forces the accumulated amplitude to zero

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d57d60b220832580b34452621b88bc