### PR TITLE
Add fighter squad control and AI updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,8 +780,32 @@ window.addEventListener('keydown', e=>{
     if(boost.state==='idle' && boost.fuel>=boost.cost){ boost.state='charging'; boost.charge=0; }
   }
   if(k === 'x') triggerScanWave();
-  if(k === 'z'){
-    for(let i=0;i<FIGHTERS_PER_LAUNCH;i++) spawnFighter();
+  if (k === 'z') {
+    if (SQUAD.order === 'idle' || SQUAD.list.length === 0) {
+      // 1) start + orbit
+      SQUAD.list = [];
+      for (let i = 0; i < FIGHTERS_PER_LAUNCH; i++) {
+        const f = spawnFighter();
+        SQUAD.list.push(f);
+      }
+      SQUAD.order = 'orbit';
+      SQUAD.targets = [];
+      toast('Myśliwce: ORBITUJ');
+    } else if (SQUAD.order === 'orbit') {
+      // 2) atak oznaczonych celów
+      SQUAD.targets = pickSquadTargets();
+      SQUAD.order = 'attack';
+      toast(SQUAD.targets.length ? 'Myśliwce: ATAK' : 'Myśliwce: ATAK (brak oznaczeń — wybiorą najbliższych)');
+    } else if (SQUAD.order === 'attack') {
+      // 3) powrót do statku
+      SQUAD.order = 'return';
+      toast('Myśliwce: POWRÓT');
+    } else if (SQUAD.order === 'return') {
+      // po powrocie możesz znów przejść do orbity
+      SQUAD.order = 'orbit';
+      SQUAD.targets = [];
+      toast('Myśliwce: ORBITUJ');
+    }
   }
   if(k === 'r'){
     if(highlightedEnemies.length){
@@ -987,12 +1011,74 @@ const FIGHTER_ATTACK_RANGE = 1000;
 const FIGHTERS_PER_LAUNCH = 10;
 
 function fighterAI(dt){
-  const target = (scan.scanned && !scan.scanned.dead &&
-    Math.hypot(scan.scanned.x - ship.pos.x, scan.scanned.y - ship.pos.y) < FIGHTER_ATTACK_RANGE)
-    ? scan.scanned : null;
+  // 1) ROZKAZ POWRÓT — leć do statku i "zadokuj"
+  if (SQUAD.order === 'return') {
+    const dx = ship.pos.x - this.x;
+    const dy = ship.pos.y - this.y;
+    const desired = Math.atan2(dy, dx);
+    const current = Math.atan2(this.vy, this.vx);
+    const diff = wrapAngle(desired - current);
+    const turn = clamp(diff, -this.turn*dt, this.turn*dt);
+    const ang = current + turn;
 
-  if(target){
-    // attack behaviour
+    this.vx += Math.cos(ang) * this.accel * dt;
+    this.vy += Math.sin(ang) * this.accel * dt;
+    limitSpeed(this, this.maxSpeed);
+
+    // lekkie VFX silników
+    for (const e of this.engines){
+      const off = rotate(e, ang + Math.PI);
+      spawnParticle({x:this.x + off.x, y:this.y + off.y},
+                    {x:this.vx - Math.cos(ang)*80, y:this.vy - Math.sin(ang)*80},
+                    0.10, '#cfe7ff', 0.8);
+    }
+
+    // docking/zwolnienie
+    const d = Math.hypot(dx, dy);
+    if (d < 40) {
+      // "wchłonięcie" do statku
+      this.dead = true;
+      const i = SQUAD.list.indexOf(this);
+      if (i !== -1) SQUAD.list.splice(i, 1);
+      if (SQUAD.list.length === 0) {
+        SQUAD.order = 'idle';
+        SQUAD.targets = [];
+        toast('Myśliwce: ZADOKOWANE');
+      }
+    }
+    return;
+  }
+
+  // 2) WYBÓR CELU
+  let target = null;
+
+  if (SQUAD.order === 'attack') {
+    // preferuj wybrane cele z rozkazu
+    if (SQUAD.targets.length) {
+      const idx = Math.max(0, SQUAD.list.indexOf(this));
+      const t = SQUAD.targets[idx % SQUAD.targets.length];
+      if (t && !t.dead) target = t;
+    }
+    // fallback: najbliższy wróg
+    if (!target) {
+      let best=null, bd=Infinity;
+      for (const n of npcs) {
+        if (n.dead || n.friendly) continue;
+        const d = Math.hypot(n.x - this.x, n.y - this.y);
+        if (d < bd) { bd = d; best = n; }
+      }
+      target = best;
+    }
+  } else {
+    // orbit mode: jeśli b. blisko oznaczonego/zeskanowanego — chwilowy atak
+    if (scan.scanned && !scan.scanned.dead &&
+        Math.hypot(scan.scanned.x - this.x, scan.scanned.y - this.y) < FIGHTER_ATTACK_RANGE) {
+      target = scan.scanned;
+    }
+  }
+
+  // 3) JEŚLI MAMY CEL → ATAK, w przeciwnym razie → ORBITA
+  if (target){
     const dx = target.x - this.x;
     const dy = target.y - this.y;
     const desired = Math.atan2(dy, dx);
@@ -1000,15 +1086,19 @@ function fighterAI(dt){
     const diff = wrapAngle(desired - current);
     const turn = clamp(diff, -this.turn*dt, this.turn*dt);
     const ang = current + turn;
+
     this.vx += Math.cos(ang) * this.accel * dt;
     this.vy += Math.sin(ang) * this.accel * dt;
     limitSpeed(this, this.maxSpeed);
+
     for(const e of this.engines){
       const off = rotate(e, ang + Math.PI);
       spawnParticle({x:this.x + off.x, y:this.y + off.y},
                     {x:this.vx - Math.cos(ang)*80, y:this.vy - Math.sin(ang)*80},
                     0.10, '#cfe7ff', 0.8);
     }
+
+    // CIWS + rakiety jak wcześniej
     this.ciwsCd = Math.max(0, this.ciwsCd - dt);
     this.missileCd = Math.max(0, this.missileCd - dt);
     const dir = {x:Math.cos(ang), y:Math.sin(ang)};
@@ -1029,7 +1119,7 @@ function fighterAI(dt){
     return;
   }
 
-  // orbit behaviour
+  // ORBITA WOKÓŁ STATKU
   this.orbitAngle += this.orbitSpeed * dt;
   const tx = ship.pos.x + Math.cos(this.orbitAngle) * this.orbitRadius;
   const ty = ship.pos.y + Math.sin(this.orbitAngle) * this.orbitRadius;
@@ -1040,9 +1130,11 @@ function fighterAI(dt){
   const diff = wrapAngle(desired - current);
   const turn = clamp(diff, -this.turn*dt, this.turn*dt);
   const ang = current + turn;
+
   this.vx += Math.cos(ang) * this.accel * dt;
   this.vy += Math.sin(ang) * this.accel * dt;
   limitSpeed(this, this.maxSpeed);
+
   for(const e of this.engines){
     const off = rotate(e, ang + Math.PI);
     spawnParticle({x:this.x + off.x, y:this.y + off.y},
@@ -1051,13 +1143,29 @@ function fighterAI(dt){
   }
 }
 
+// === FIGHTER SQUAD STATE ===
+const SQUAD = {
+  order: 'idle',       // 'idle' | 'orbit' | 'attack' | 'return'
+  list: [],            // referencje do obiektów fighterów w npcs
+  targets: [],         // wybrane cele przy rozkazie "attack"
+};
+
+function pickSquadTargets() {
+  const aliveLocked = lockedTargets.filter(t => !t.dead);
+  if (aliveLocked.length) return aliveLocked;
+  if (lockedTarget && !lockedTarget.dead) return [lockedTarget];
+  // fallback: brak oznaczeń → będzie wybór najbliższego w AI
+  return [];
+}
+
 function spawnFighter(){
   const pod = ship.pods[ship.nextFighterPod % ship.pods.length];
   ship.nextFighterPod = (ship.nextFighterPod + 1) % ship.pods.length;
   const off = rotate(pod.offset, ship.angle);
   const orbit = ship.nextFighterOrbit;
   ship.nextFighterOrbit = (ship.nextFighterOrbit + Math.PI*2 / FIGHTERS_PER_LAUNCH) % (Math.PI*2);
-  npcs.push({
+
+  const f = {
     x: ship.pos.x + off.x,
     y: ship.pos.y + off.y,
     vx: ship.vel.x,
@@ -1065,12 +1173,15 @@ function spawnFighter(){
     accel:600, maxSpeed:900, turn:6,
     radius:12, hp:40, maxHp:40, color:'#9edfff', fade:1,
     ai: fighterAI, mission:true, friendly:true,
+    fighter: true,                         // ← flaga pomocnicza
     ciwsCd:0, missileCd:0, missiles:2,
     engines:[{x:-3,y:8},{x:3,y:8}],
     orbitAngle: orbit,
     orbitRadius: FIGHTER_ORBIT_RADIUS,
-    orbitSpeed: FIGHTER_ORBIT_SPEED
-  });
+    orbitSpeed: FIGHTER_ORBIT_SPEED,
+  };
+  npcs.push(f);
+  return f; // ← ważne
 }
 
 // =============== Rail (2 lufy: serie A→B, A→B) ===============


### PR DESCRIPTION
## Summary
- add a fighter squad state block with helper targeting logic
- change the Z key handler to cycle through launch, attack, and return orders
- rewrite fighter AI and spawning so ships follow squad orders and report docking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7f5bf8ba8832597848e5a421dd45d