### PR TITLE
Fix warp toggle, hangar repairs, and NPC AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,9 +362,6 @@ function makeNPCBase(pos, stats){
   };
 }
 
-function chaseEvadeAI(){/* stub */}
-function battleshipAI(){/* stub */}
-function dogfightAI(){/* stub */}
 function makeRailgun(cfg){ return { ...cfg }; }
 function makeRocketPod(cfg){ return { ...cfg }; }
 function makeGatling(cfg){ return { ...cfg }; }
@@ -590,7 +587,6 @@ function spawnShockwave(x, y, opts = {}){
 }
 
 // =============== Station UI ===============
-const STATIONS = stations; // istniejące lub generowane
 let stationUI = {
   open:false,
   tab:'upgrades',
@@ -615,7 +611,7 @@ let OPTIONS_OPEN = false;
 
 function stationUnderCursor(){
   const world = screenToWorld(mouse.x, mouse.y);
-  for(const s of STATIONS){
+  for(const s of stations){
     const d = Math.hypot(world.x - s.x, world.y - s.y);
     if(d < (s.r||120)) return s;
   }
@@ -662,12 +658,16 @@ function renderStationUI(){
 }
 
 // --- Zakładki ---
-const PLAYER = { credits: 1200, cargo: {}, shipId: 'starter', hull: 0.86 };
+const PLAYER = { credits: 1200, cargo: {}, shipId: 'starter' };
 const BLUEPRINTS = {
   upgrades: [
     { id:'rail_cooler', name:'Chłodzenie raila', cost:600, apply(){ rail.heatCap *= 1.25; rail.coolRate *= 1.15; } },
     { id:'boost_core',  name:'Wzmocniony boost', cost:700, apply(){ boost.speed *= 1.15; boost.duration *= 1.1; } },
-    { id:'agility',     name:'Zwrotność +',      cost:500, apply(){ ship.turnRate = (ship.turnRate||1)*1.12; } },
+    { id:'agility',     name:'Zwrotność +',      cost:500, apply(){
+      ship.angularDamping *= 0.9;
+      ship.engines.torqueLeft.maxThrust  = Math.round(ship.engines.torqueLeft.maxThrust * 1.12);
+      ship.engines.torqueRight.maxThrust = Math.round(ship.engines.torqueRight.maxThrust * 1.12);
+    } },
   ],
   ships: [
     { id:'scout', name:'Scout', cost:2500, stats:{ hp:0.8, speed:1.3, cargo:0.6 } },
@@ -714,9 +714,19 @@ function renderCantinaTab(){
 }
 function renderHangarTab(){
   uiTitle('Hangar');
-  if(uiRowButton(`Napraw kadłub (${Math.ceil((1-PLAYER.hull)*100)}% uszk.)`, 'Napraw')){
-    const cost = Math.ceil((1-PLAYER.hull)*600);
-    if(PLAYER.credits>=cost){ PLAYER.credits-=cost; PLAYER.hull=1.0; toast('Naprawiono kadłub.'); } else toast('Za mało kredytów');
+
+  const damageFrac = 1 - (ship.hull.val / ship.hull.max);
+  const damagePct = Math.ceil(damageFrac * 100);
+  const cost = Math.ceil(damageFrac * 600);
+
+  if(uiRowButton(`Napraw kadłub (${damagePct}% uszk.)`, 'Napraw')){
+    if(PLAYER.credits >= cost){
+      PLAYER.credits -= cost;
+      ship.hull.val = ship.hull.max;
+      toast('Naprawiono kadłub.');
+    } else {
+      toast('Za mało kredytów');
+    }
   }
   section('Nowe statki');
   for(const s of BLUEPRINTS.ships){
@@ -773,10 +783,13 @@ let showMap = false;
 let PAUSED = false;
 window.addEventListener('keydown', e=>{
   if(e.repeat) return;
+  if(e.code==='Space'){ e.preventDefault(); }
+  if(e.code==='ShiftLeft' || e.code==='ShiftRight'){ e.preventDefault(); }
   const k = e.key.toLowerCase();
   keys[k] = true;
   if(k === 'm') showMap = !showMap;
   if(e.key === ' '){
+    e.preventDefault();
     if(boost.state==='idle' && boost.fuel>=boost.cost){ boost.state='charging'; boost.charge=0; }
   }
   if(k === 'x') triggerScanWave();
@@ -1706,6 +1719,24 @@ const boost = {
   fuelMax:3, fuel:3, cost:1, regenRate:0.5,
   effectTime:0, effectDuration:0.4, effectDir:{x:0,y:0}
 };
+
+function attemptWarp(){
+  if (warp.state === 'idle' && warp.fuel > 0) {
+    warp.state = 'charging';
+    warp.charge = 0;
+    return;
+  }
+  if (warp.state === 'charging') {
+    warp.state = 'idle';
+    warp.charge = 0;
+    return;
+  }
+  if (warp.state === 'active') {
+    warp.state = 'idle';
+    exitWarp();
+  }
+}
+
 function engageBoost(){
   const dir = rotate({x:0,y:-1}, ship.angle);
   ship.vel.x += dir.x * boost.speed;
@@ -2911,7 +2942,19 @@ function slider(label, min,max, step, obj, key){
   // Możesz podpiąć realny input według swojej architektury.
 }
 function toast(t){ /* opcjonalnie dopisz do kolejki komunikatów HUD */ }
-function applyShipStats(s){ ship.hpMax*=s.hp; ship.maxSpeed*=s.speed; ship.cargoCap=(ship.cargoCap||20)*s.cargo; }
+function applyShipStats(s){
+  ship.hull.max = Math.round(ship.hull.max * s.hp);
+  ship.hull.val = Math.min(ship.hull.val, ship.hull.max);
+
+  const speedMul = s.speed;
+  ship.engines.main.maxThrust      = Math.round(ship.engines.main.maxThrust * speedMul);
+  ship.engines.sideLeft.maxThrust  = Math.round(ship.engines.sideLeft.maxThrust * speedMul);
+  ship.engines.sideRight.maxThrust = Math.round(ship.engines.sideRight.maxThrust * speedMul);
+  ship.engines.torqueLeft.maxThrust  = Math.round(ship.engines.torqueLeft.maxThrust * speedMul);
+  ship.engines.torqueRight.maxThrust = Math.round(ship.engines.torqueRight.maxThrust * speedMul);
+
+  ship.cargoCap = Math.round((ship.cargoCap || 20) * s.cargo);
+}
 
 function dist(x1,y1,x2,y2){ return Math.hypot(x2-x1, y2-y1); }
 function limitSpeed(n, max){
@@ -2924,20 +2967,41 @@ function limitSpeed(n, max){
     else { n.vx*=s; n.vy*=s; }
   }
 }
-function chaseEvadeAI(n, target, opts={}){
-  // prosta pogoń z unikami
-  const dx=target.pos.x-n.pos.x, dy=target.pos.y-n.pos.y;
-  const ang=Math.atan2(dy,dx), da=wrapAngle(ang-n.rot);
-  n.rot += clamp(da,-n.turn*0.016,n.turn*0.016);
-  n.vel.x += Math.cos(n.rot)*n.accel*0.016;
-  n.vel.y += Math.sin(n.rot)*n.accel*0.016;
+function steerToward(n, tx, ty, dt, accel = n.accel, turnRate = n.turn) {
+  const desired = Math.atan2(ty - n.y, tx - n.x);
+  const diff = wrapAngle(desired - n.angle);
+  const turn = clamp(diff, -turnRate * dt, turnRate * dt);
+  n.angle = wrapAngle(n.angle + turn);
+  n.vx += Math.cos(n.angle) * accel * dt;
+  n.vy += Math.sin(n.angle) * accel * dt;
   limitSpeed(n, n.maxSpeed);
 }
-function dogfightAI(n, target){ return chaseEvadeAI(n,target,{strafe:true}); }
-function battleshipAI(n, target){ // wolniejszy obrót – trzyma dystans
-  const d = dist(n.pos.x,n.pos.y,target.pos.x,target.pos.y);
-  if(d<600){ n.vel.x -= Math.cos(n.rot)*n.accel*0.016; n.vel.y -= Math.sin(n.rot)*n.accel*0.016; }
-  else chaseEvadeAI(n,target);
+
+function chaseEvadeAI(n, target, opts = {}) {
+  steerToward(n, target.pos.x, target.pos.y, 0.016);
+
+  if (opts.strafe) {
+    const side = (Math.random() < 0.5 ? -1 : 1);
+    const ang = n.angle + side * Math.PI / 2;
+    n.vx += Math.cos(ang) * n.accel * 0.004;
+    n.vy += Math.sin(ang) * n.accel * 0.004;
+  }
+}
+
+function dogfightAI(n, target) {
+  chaseEvadeAI(n, target, { strafe: true });
+}
+
+function battleshipAI(n, target) {
+  const d = Math.hypot(target.pos.x - n.x, target.pos.y - n.y);
+  if (d < 600) {
+    const ang = Math.atan2(n.y - target.pos.y, n.x - target.pos.x);
+    n.vx += Math.cos(ang) * n.accel * 0.016;
+    n.vy += Math.sin(ang) * n.accel * 0.016;
+    limitSpeed(n, n.maxSpeed);
+  } else {
+    chaseEvadeAI(n, target);
+  }
 }
 function useRailPair(n, target){ /* sprawdź kąt i cooldown, odpal pary */ }
 function useRocketsPair(n, target){ /* salwy */ }


### PR DESCRIPTION
## Summary
- add an attemptWarp toggle for gamepad input and block browser defaults for space/shift
- repair hangar actions and ship upgrades so they operate on the live ship stats
- replace NPC AI helpers with implementations that steer using x/y/vx/vy/angle data and drop the stale station alias

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7fff1fe6c8325a6c4059f088135ba