### PR TITLE
Add pirate station mission arrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -3096,6 +3096,63 @@ function render(alpha){
     }
   }
 
+  // mercenary mission arrow towards pirate station
+  if(mercMission && mercMission.station){
+    const st = mercMission.station;
+    const dx = st.x - ship.pos.x;
+    const dy = st.y - ship.pos.y;
+    const dist = Math.hypot(dx, dy);
+    if(dist > 1){
+      const ang = Math.atan2(dy, dx);
+      const shipScreen = worldToScreen(ship.pos.x, ship.pos.y, cam);
+      const distScreen = dist * camera.zoom;
+      const maxRadius = Math.max(160, Math.min(W, H) * 0.5 - 60);
+      const baseMinRadius = (ship.h * 0.5 + 80) * camera.zoom;
+      const minRadius = Math.min(baseMinRadius, maxRadius);
+      let arrowRadius = distScreen;
+      arrowRadius = Math.max(arrowRadius, minRadius);
+      arrowRadius = Math.min(arrowRadius, maxRadius);
+      const ax = shipScreen.x + Math.cos(ang) * arrowRadius;
+      const ay = shipScreen.y + Math.sin(ang) * arrowRadius;
+
+      const baseArrowLength = ship.h / camera.zoom;
+      const arrowLength = clamp(baseArrowLength, ship.h * 0.6, Math.min(Math.min(W, H) * 0.6, ship.h * 2.6));
+      const arrowWidth = arrowLength * 0.35;
+      const strokeW = clamp(6 / camera.zoom, 2, 12);
+
+      ctx.save();
+      ctx.translate(ax, ay);
+      ctx.rotate(ang);
+      ctx.beginPath();
+      ctx.moveTo(arrowLength * 0.5, 0);
+      ctx.lineTo(-arrowLength * 0.5, -arrowWidth * 0.5);
+      ctx.lineTo(-arrowLength * 0.5, arrowWidth * 0.5);
+      ctx.closePath();
+      ctx.fillStyle = 'rgba(255,90,90,0.92)';
+      ctx.shadowColor = 'rgba(255,120,120,0.6)';
+      ctx.shadowBlur = 14;
+      ctx.fill();
+      ctx.lineWidth = strokeW;
+      ctx.strokeStyle = 'rgba(10,0,0,0.55)';
+      ctx.stroke();
+      ctx.restore();
+
+      const labelDist = arrowLength * 0.55;
+      const labelX = ax + Math.cos(ang) * labelDist;
+      const labelY = ay + Math.sin(ang) * labelDist;
+      const fontSize = Math.round(clamp(20 / camera.zoom, 14, 34));
+      ctx.save();
+      ctx.fillStyle = '#ffd1d1';
+      ctx.font = `bold ${fontSize}px monospace`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText('PIRACKA STACJA', labelX, labelY - 6);
+      ctx.textBaseline = 'top';
+      ctx.fillText(`${Math.round(dist)} u`, labelX, labelY + 6);
+      ctx.restore();
+    }
+  }
+
   // Particles typu "flash" na samym wierzchu
   {
     let drawn = 0;


### PR DESCRIPTION
## Summary
- add a prominent UI arrow that appears after starting the mercenary mission and points toward the pirate station
- scale the arrow and mission label inversely to the current camera zoom so it stays legible when zooming out

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d81e3eeab88325b571c4e11bd008bc