### PR TITLE
Extend booster duration and regeneration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2126,8 +2126,8 @@ function exitWarp(){
 
 const boost = {
   state:'idle',
-  fuelMax:3, fuel:3,
-  regenRate:0.5,
+  fuelMax:15, fuel:15,
+  regenRate:0.7,
   consumeRate:1.5,
   extraThrustMul:0.8,
   handlingMultiplier:1.35,


### PR DESCRIPTION
## Summary
- increase the boost fuel pool to allow 10 seconds of sustained thrust
- slightly speed up boost fuel regeneration to recover faster between uses

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d97a3f4ea0832586d5e896af1c8cfd