### PR TITLE
Add floating HUD overlays and navigation indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,6 +374,105 @@ function drawHardpointGizmos(ctx, worldPos){
   ctx.restore();
 }
 
+// =============== Floating HUD state ===============
+const HUD_SHOW_LEGACY = false; // stary HUD w lewym dolnym rogu – zostaw false
+
+const HUD = {
+  dmg: [],       // popupy obrażeń: {x,y,txt,color,vy,life,max}
+  navArrows: [], // niebieskie strzałki po X: {x,y,age,life}
+};
+
+function hudSpawnDMG(x,y,amount,kind='npc'){
+  const color = (kind==='player') ? '#f87171' : '#a7f3d0';
+  HUD.dmg.push({ x, y, txt: Math.round(amount), color, vy: -14, life: 1.15, max: 1.15 });
+}
+function hudUpdateDMG(dt){
+  for(const d of HUD.dmg){ d.y += d.vy*dt; d.life -= dt; }
+  HUD.dmg = HUD.dmg.filter(d=>d.life>0);
+}
+function hudRenderDMG(cam){
+  ctx.save();
+  ctx.font = 'bold 13px system-ui,monospace';
+  ctx.textAlign = 'center';
+  for(const d of HUD.dmg){
+    const s = worldToScreen(d.x, d.y, cam);
+    ctx.globalAlpha = Math.max(0, d.life/d.max);
+    ctx.fillStyle = d.color;
+    ctx.fillText(d.txt, s.x, s.y);
+  }
+  ctx.restore();
+}
+
+function hudPingNpcStations(){
+  // Niebieskie strzałki do stacji nie-misyjnych; gasną po 4s
+  const targets = stations.filter(s=>!s.mission).slice(0, 8);
+  HUD.navArrows = targets.map(s=>({ x:s.x, y:s.y, age:0, life:4.0 }));
+}
+function hudUpdateNav(dt){
+  for(const p of HUD.navArrows) p.age += dt;
+  HUD.navArrows = HUD.navArrows.filter(p=>p.age < p.life);
+}
+
+function drawArrowOnRing(cx, cy, R, ang, size, color){
+  const x = cx + Math.cos(ang)*R, y = cy + Math.sin(ang)*R;
+  ctx.save(); ctx.translate(x,y); ctx.rotate(ang);
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(size, 0);
+  ctx.lineTo(-size*0.6, size*0.6);
+  ctx.lineTo(-size*0.2, 0);
+  ctx.lineTo(-size*0.6, -size*0.6);
+  ctx.closePath(); ctx.fill();
+  ctx.restore();
+}
+function hudRenderNav(ship, cam){
+  if(!HUD.navArrows.length) return;
+  const s = worldToScreen(ship.pos.x, ship.pos.y, cam);
+  const R = Math.max(ship.w, ship.h) * camera.zoom * 0.6 + 30;
+  for(const p of HUD.navArrows){
+    const ang = Math.atan2(p.y - ship.pos.y, p.x - ship.pos.x);
+    const a = Math.max(0, 1 - p.age/p.life);
+    ctx.save(); ctx.globalAlpha = 0.3 + 0.7*a;
+    drawArrowOnRing(s.x, s.y, R, ang, 12, '#60a5fa');
+    ctx.restore();
+  }
+}
+
+function hudRenderFloatingBars(ship, cam){
+  const center = worldToScreen(ship.pos.x, ship.pos.y, cam);
+  const cx = center.x, cy = center.y;
+  const R0 = Math.max(ship.w, ship.h) * camera.zoom * 0.8 + 32;
+
+  // BOOST – pokazuj przy ładowaniu lub krótkim efekcie
+  if (boost.state === 'charging' || boost.effectTime > 0){
+    const t = (boost.state==='charging')
+      ? Math.min(1, boost.charge/boost.chargeTime)
+      : Math.max(0, boost.effectTime/boost.effectDuration);
+    ctx.save();
+    ctx.strokeStyle = 'rgba(41,52,65,0.9)'; ctx.lineWidth = 8;
+    ctx.beginPath(); ctx.arc(cx, cy, R0, -Math.PI/2, -Math.PI/2 + Math.PI*1.1); ctx.stroke();
+    ctx.strokeStyle = '#60a5fa';
+    ctx.beginPath(); ctx.arc(cx, cy, R0, -Math.PI/2, -Math.PI/2 + Math.PI*1.1*t); ctx.stroke();
+    ctx.fillStyle = '#bcd7ff'; ctx.font = '12px system-ui,monospace'; ctx.textAlign = 'center';
+    ctx.fillText('BOOST', cx, cy - R0 - 10);
+    ctx.restore();
+  }
+
+  // WARP – pokazuj przy charge/active
+  if (warp.state === 'charging' || warp.state === 'active'){
+    const t = (warp.state==='charging') ? Math.min(1, warp.charge/warp.chargeTime) : 1;
+    const R1 = R0 + 16;
+    ctx.save();
+    ctx.strokeStyle = 'rgba(30,41,59,0.9)'; ctx.lineWidth = 8;
+    ctx.beginPath(); ctx.arc(cx, cy, R1,  Math.PI/2,  Math.PI/2 - Math.PI*1.1, true); ctx.stroke();
+    ctx.strokeStyle = '#7dd3fc';
+    ctx.beginPath(); ctx.arc(cx, cy, R1,  Math.PI/2,  Math.PI/2 - Math.PI*1.1*t, true); ctx.stroke();
+    ctx.fillStyle = '#d0f0ff'; ctx.font = '12px system-ui,monospace'; ctx.textAlign = 'center';
+    ctx.fillText('WARP', cx, cy + R1 + 26);
+    ctx.restore();
+  }
+}
+
 // =============== Game time (1 min real = 1 h game) ===============
 const TIME_SCALE = 60; // game seconds per real second
 let gameTime = 0; // seconds
@@ -1405,7 +1504,7 @@ window.addEventListener('keydown', e=>{
     e.preventDefault();
     if(boost.fuel>0){ boost.state='active'; }
   }
-  if(k === 'x') triggerScanWave();
+  if(k === 'x'){ triggerScanWave(); hudPingNpcStations(); }
   if (k === 'z') {
     if(!(Game.player.weapons?.[HP.HANGAR]?.length)) { toast('Brak dostępnych hangarów.'); return; }
     if (SQUAD.order === 'idle' || SQUAD.list.length === 0) {
@@ -2186,12 +2285,14 @@ function tryFireSpecial(){
 function applyDamageToPlayer(amount){
   if(ship.shield.val>0){ const s = Math.min(ship.shield.val, amount); ship.shield.val -= s; amount -= s; ship.shield.regenTimer = ship.shield.regenDelay; }
   if(amount>0) ship.hull.val = Math.max(0, ship.hull.val - amount);
+  hudSpawnDMG(ship.pos.x, ship.pos.y - ship.h*0.4, amount, 'player');
 }
 function applyDamageToNPC(npc, dmg, cause='default'){
   if(npc.dead) return;
   npc.hitFlash = 0.12;
   npc.damageHue = (npc.damageHue || 0) + dmg;
   npc.hp -= dmg;
+  hudSpawnDMG(npc.x, npc.y - (npc.radius||20)*0.8, dmg, 'npc');
   if(npc.hp<=0){
     npc.dead = true; npc.respawnTimer = 3 + Math.random()*6;
     if(cause === 'plasma'){ spawnExplosionPlasma(npc.x, npc.y, 1.2); }
@@ -2994,6 +3095,8 @@ function physicsStep(dt){
   ciwsStep(dt);
   bulletsAndCollisionsStep(dt);
   npcShootingStep(dt);
+  hudUpdateDMG(dt);
+  hudUpdateNav(dt);
 }
 
 // ======= Efekty VFX =======
@@ -3686,6 +3789,10 @@ function render(alpha){
     drawNPCPretty(ctx, npc, s);
   }
 
+  hudRenderNav(ship, cam);
+  hudRenderDMG(cam);
+  hudRenderFloatingBars(ship, cam);
+
   // radar pings
   for(const ping of radarPings){
     const s = worldToScreen(ping.x, ping.y, cam);
@@ -4028,41 +4135,45 @@ function render(alpha){
       const ax = shipScreen.x + Math.cos(ang) * arrowRadius;
       const ay = shipScreen.y + Math.sin(ang) * arrowRadius;
 
-      const baseArrowLength = (visualH / camera.zoom) * 0.2;
-      const arrowLength = clamp(baseArrowLength, visualH * 0.45, Math.min(Math.min(W, H) * 0.2, visualH * 0.7));
-      const arrowWidth = arrowLength * 0.28;
-      const strokeW = clamp(4 / camera.zoom, 1.6, 9);
+        // shrink + auto-hide when close to station
+        const HIDE_DIST = st.r + 600; // znikaj przy podejściu
+        if (dist > HIDE_DIST) {
+          const baseArrowLength = (ship.h / camera.zoom) * 0.45;
+          const arrowLength = clamp(baseArrowLength, 18, 42);
+          const arrowWidth = arrowLength * 0.26;
+          const strokeW = clamp(2.5 / camera.zoom, 1.2, 5);
 
-      ctx.save();
-      ctx.translate(ax, ay);
-      ctx.rotate(ang);
-      ctx.beginPath();
-      ctx.moveTo(arrowLength * 0.5, 0);
-      ctx.lineTo(-arrowLength * 0.5, -arrowWidth * 0.5);
-      ctx.lineTo(-arrowLength * 0.5, arrowWidth * 0.5);
-      ctx.closePath();
-      ctx.fillStyle = 'rgba(255,90,90,0.92)';
-      ctx.shadowColor = 'rgba(255,120,120,0.6)';
-      ctx.shadowBlur = 14;
-      ctx.fill();
-      ctx.lineWidth = strokeW;
-      ctx.strokeStyle = 'rgba(10,0,0,0.55)';
-      ctx.stroke();
-      ctx.restore();
+          ctx.save();
+          ctx.translate(ax, ay);
+          ctx.rotate(ang);
+          ctx.beginPath();
+          ctx.moveTo(arrowLength * 0.5, 0);
+          ctx.lineTo(-arrowLength * 0.5, -arrowWidth * 0.5);
+          ctx.lineTo(-arrowLength * 0.5, arrowWidth * 0.5);
+          ctx.closePath();
+          ctx.fillStyle = 'rgba(255,90,90,0.92)';
+          ctx.shadowColor = 'rgba(255,120,120,0.6)';
+          ctx.shadowBlur = 14;
+          ctx.fill();
+          ctx.lineWidth = strokeW;
+          ctx.strokeStyle = 'rgba(10,0,0,0.55)';
+          ctx.stroke();
+          ctx.restore();
 
-      const labelDist = arrowLength * 0.45;
-      const labelX = ax + Math.cos(ang) * labelDist;
-      const labelY = ay + Math.sin(ang) * labelDist;
-      const fontSize = Math.round(clamp(16 / camera.zoom, 10, 26));
-      ctx.save();
-      ctx.fillStyle = '#ffd1d1';
-      ctx.font = `bold ${fontSize}px monospace`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'bottom';
-      ctx.fillText('PIRACKA STACJA', labelX, labelY - 6);
-      ctx.textBaseline = 'top';
-      ctx.fillText(`${Math.round(dist)} u`, labelX, labelY + 6);
-      ctx.restore();
+          const labelDist = arrowLength * 0.45;
+          const labelX = ax + Math.cos(ang) * labelDist;
+          const labelY = ay + Math.sin(ang) * labelDist;
+          const fontSize = Math.round(clamp(16 / camera.zoom, 10, 26));
+          ctx.save();
+          ctx.fillStyle = '#ffd1d1';
+          ctx.font = `bold ${fontSize}px monospace`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'bottom';
+          ctx.fillText('PIRACKA STACJA', labelX, labelY - 6);
+          ctx.textBaseline = 'top';
+          ctx.fillText(`${Math.round(dist)} u`, labelX, labelY + 6);
+          ctx.restore();
+        }
     }
   }
 
@@ -4093,31 +4204,33 @@ function render(alpha){
     }
   }
 
-  // HUD
-  ctx.fillStyle = '#dfe7ff'; ctx.font = '12px monospace';
-  ctx.fillText(`HP: ${Math.round(ship.hull.val)}/${ship.hull.max}`, 12, H-100);
-  ctx.fillText(`Shield: ${Math.round(ship.shield.val)}/${ship.shield.max}`, 12, H-84);
-  const warpText = warp.state==='active' ? `ACTIVE`
-                  : warp.state==='charging' ? `CHARGING ${(Math.min(1,warp.charge/warp.chargeTime)*100).toFixed(0)}%`
-                  : 'READY';
-  ctx.fillText(`Warp: ${warpText}`, 12, H-68);
-  const fw = 200, fh = 10, ffrac = warp.fuel/warp.fuelMax;
-  ctx.strokeStyle = 'rgba(255,255,255,0.14)'; ctx.strokeRect(12-1, H-52-fh, fw+2, fh+2);
-  ctx.fillStyle = '#60a5fa'; ctx.fillRect(12, H-52-fh, fw*ffrac, fh);
-  ctx.fillStyle = '#dfe7ff'; ctx.fillText(`${warp.fuel.toFixed(1)}s / ${warp.fuelMax}s`, 12 + fw + 8, H-42-fh);
-  const boosting = boost.state==='active' && boost.fuel > 0;
-  const fullyCharged = boost.fuel >= boost.fuelMax - 0.01;
-  const boostText = boosting ? 'ACTIVE' : (fullyCharged ? 'READY' : 'REFILLING');
-  ctx.fillText(`Boost: ${boostText} (${boost.fuel.toFixed(1)}/${boost.fuelMax})`, 12, H-44);
-  const railTimerHUD = Math.min(rail.cd[0], rail.cd[1]);
-  ctx.fillText(`Rail: ${railTimerHUD>0?railTimerHUD.toFixed(2)+'s':'READY'}  Special: ${ship.special.cooldownTimer>0?ship.special.cooldownTimer.toFixed(1)+'s':'READY'}`, 12, H-28);
+  if (HUD_SHOW_LEGACY) {
+    // HUD
+    ctx.fillStyle = '#dfe7ff'; ctx.font = '12px monospace';
+    ctx.fillText(`HP: ${Math.round(ship.hull.val)}/${ship.hull.max}`, 12, H-100);
+    ctx.fillText(`Shield: ${Math.round(ship.shield.val)}/${ship.shield.max}`, 12, H-84);
+    const warpText = warp.state==='active' ? `ACTIVE`
+                    : warp.state==='charging' ? `CHARGING ${(Math.min(1,warp.charge/warp.chargeTime)*100).toFixed(0)}%`
+                    : 'READY';
+    ctx.fillText(`Warp: ${warpText}`, 12, H-68);
+    const fw = 200, fh = 10, ffrac = warp.fuel/warp.fuelMax;
+    ctx.strokeStyle = 'rgba(255,255,255,0.14)'; ctx.strokeRect(12-1, H-52-fh, fw+2, fh+2);
+    ctx.fillStyle = '#60a5fa'; ctx.fillRect(12, H-52-fh, fw*ffrac, fh);
+    ctx.fillStyle = '#dfe7ff'; ctx.fillText(`${warp.fuel.toFixed(1)}s / ${warp.fuelMax}s`, 12 + fw + 8, H-42-fh);
+    const boosting = boost.state==='active' && boost.fuel > 0;
+    const fullyCharged = boost.fuel >= boost.fuelMax - 0.01;
+    const boostText = boosting ? 'ACTIVE' : (fullyCharged ? 'READY' : 'REFILLING');
+    ctx.fillText(`Boost: ${boostText} (${boost.fuel.toFixed(1)}/${boost.fuelMax})`, 12, H-44);
+    const railTimerHUD = Math.min(rail.cd[0], rail.cd[1]);
+    ctx.fillText(`Rail: ${railTimerHUD>0?railTimerHUD.toFixed(2)+'s':'READY'}  Special: ${ship.special.cooldownTimer>0?ship.special.cooldownTimer.toFixed(1)+'s':'READY'}`, 12, H-28);
 
-  // rocket ammo
-  const bw = 160, bh = 10;
-  const ammoFrac = rocketAmmoMax > 0 ? rocketAmmo / rocketAmmoMax : 0;
-  ctx.strokeStyle = 'rgba(255,255,255,0.12)'; ctx.strokeRect(12-1, H-12-bh-12, bw+2, bh+2);
-  ctx.fillStyle = '#3b82f6'; ctx.fillRect(12, H-12-bh-12, bw*ammoFrac, bh);
-  ctx.fillStyle = '#dfe7ff'; ctx.fillText(`Rockets: ${rocketAmmo}`, 12 + bw + 8, H-12-bh-6-12);
+    // rocket ammo
+    const bw = 160, bh = 10;
+    const ammoFrac = rocketAmmoMax > 0 ? rocketAmmo / rocketAmmoMax : 0;
+    ctx.strokeStyle = 'rgba(255,255,255,0.12)'; ctx.strokeRect(12-1, H-12-bh-12, bw+2, bh+2);
+    ctx.fillStyle = '#3b82f6'; ctx.fillRect(12, H-12-bh-12, bw*ammoFrac, bh);
+    ctx.fillStyle = '#dfe7ff'; ctx.fillText(`Rockets: ${rocketAmmo}`, 12 + bw + 8, H-12-bh-6-12);
+  }
 
   if(mercMission && mercMission.station){
     const st = mercMission.station;


### PR DESCRIPTION
## Summary
- add a floating HUD system with damage popups, navigation arrows, and ship status rings
- update damage/scanning logic and the render loop to drive the new HUD while hiding the legacy overlay behind a flag
- shrink and auto-hide the pirate station guidance arrow for better readability

## Testing
- npm run start (manual smoke via screenshot)


------
https://chatgpt.com/codex/tasks/task_b_68d98a173c08832585fdac2df651fd9b