### PR TITLE
Integrate Bazyl planetary system

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,6 +697,9 @@ function initStars(reset=false){
 // =============== Słońce, planety i stacje ===============
 const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200 };
 
+const USE_BAZYL_SYSTEM = true;
+const BAZYL_SYSTEM_PATH = './systems/bazyl.system.json';
+
 const PLANET_TYPES = {
   TERRAN: 'terran',
   VOLCANIC: 'volcanic',
@@ -705,71 +708,58 @@ const PLANET_TYPES = {
   BARREN: 'barren'
 };
 
-const PLANET_DATA = (() => {
-  const NUM_PLANETS = 7;
-  const TYPES = [
-    PLANET_TYPES.VOLCANIC,
-    PLANET_TYPES.VOLCANIC,
-    PLANET_TYPES.TERRAN,
-    PLANET_TYPES.TERRAN,
-    PLANET_TYPES.BARREN,
-    PLANET_TYPES.GAS,
-    PLANET_TYPES.FROZEN
-  ];
-  const BASE_ORBIT = 7000; // stała odległość między orbitami
-  const list = [];
-  for (let i = 0; i < NUM_PLANETS; i++) {
-    const orbitRadius = BASE_ORBIT * (i + 1);
-    const angle = Math.random() * Math.PI * 2;
-    const au = i + 1; // jednostka do skalowania prędkości orbitalnej
-    // Orbital period scaled so that a planet at 1 AU orbits in 365 days
-    const periodHours = 24 * 365 * Math.pow(au, 1.5); // Kepler scaling
-    const speed = (2 * Math.PI) / (periodHours * 3600); // rad per game second
-    const r = (48 + Math.floor(Math.random() * 36)) * 3; // powiększone ~3×
-    list.push({ id: i, orbitRadius, angle, speed, r, type: TYPES[i], x: 0, y: 0 });
-  }
-  return list;
-})();
-
-let planets = PLANET_DATA.map(p => {
-  p.x = SUN.x + Math.cos(p.angle) * p.orbitRadius;
-  p.y = SUN.y + Math.sin(p.angle) * p.orbitRadius;
-  return p;
-});
-
 const STATION_STYLES = ['ringGate','hexHub','triRing','solarPetals','shipyard','tradeSpindle'];
 
-let stations = planets.map(pl => {
-  const orbitRadius = pl.r + 300;
-  const angle = Math.random() * Math.PI * 2;
-  const periodHours = 12; // stacja okrąża planetę w 12h
-  const speed = (2 * Math.PI) / (periodHours * 3600);
-  const x = pl.x + Math.cos(angle) * orbitRadius;
-  const y = pl.y + Math.sin(angle) * orbitRadius;
-  const r = 120;
-  const portOffset = r + 40;
-  const ports = [
-    {x: portOffset, y: 0},
-    {x: 0, y: portOffset},
-    {x: -portOffset, y: 0},
-    {x: 0, y: -portOffset}
-  ];
-  const style = STATION_STYLES[Math.floor(Math.random()*STATION_STYLES.length)];
-  return { id: pl.id, planet: pl, orbitRadius, angle, speed, r, x, y, ports, style };
-});
+let planets = [];
+let stations = [];
+let warpRoutes = {};
 
-// oznacz stacje wewnątrz pasa asteroid
-(() => {
+let systemReadyResolve;
+const systemReadyPromise = new Promise(resolve => {
+  systemReadyResolve = resolve;
+});
+let systemConfigured = false;
+
+function mapPlanetType(type){
+  const k = (type || '').toLowerCase();
+  if (k.includes('gas')) return 'gas';
+  if (k.includes('ice')) return 'ice';
+  if (k.includes('volc')) return PLANET_TYPES.VOLCANIC;
+  if (k.includes('bar') || k.includes('dust')) return PLANET_TYPES.BARREN;
+  if (k.includes('ter') || k.includes('rock') || k.includes('earth')) return 'terran';
+  return 'terran';
+}
+
+function buildStationsFromPlanets(planetList){
+  return planetList.map(pl => {
+    const orbitRadius = (pl.r || 120) + 300;
+    const angle = Math.random() * Math.PI * 2;
+    const periodHours = 12;
+    const speed = (2 * Math.PI) / (periodHours * 3600);
+    const x = pl.x + Math.cos(angle) * orbitRadius;
+    const y = pl.y + Math.sin(angle) * orbitRadius;
+    const r = 120;
+    const portOffset = r + 40;
+    const ports = [
+      {x: portOffset, y: 0},
+      {x: 0, y: portOffset},
+      {x: -portOffset, y: 0},
+      {x: 0, y: -portOffset}
+    ];
+    const style = STATION_STYLES[Math.floor(Math.random()*STATION_STYLES.length)];
+    return { id: pl.id, planet: pl, orbitRadius, angle, speed, r, x, y, ports, style };
+  });
+}
+
+function markStationsInner(){
   if (planets[3] && planets[4]) {
     const beltRadius = (planets[3].orbitRadius + planets[4].orbitRadius) / 2;
     for (const st of stations) st.inner = st.orbitRadius < beltRadius;
   } else {
     for (const st of stations) st.inner = true;
   }
-})();
+}
 
-// Warp routes between stations
-let warpRoutes = {};
 function initWarpRoutes(){
   warpRoutes = {};
   for(const from of stations){
@@ -795,7 +785,108 @@ function initWarpRoutes(){
   }
 }
 function getWarpRoute(fromId, toId){ return warpRoutes[fromId + '-' + toId]; }
-initWarpRoutes();
+
+function configureSystemFromData(list, sunObj){
+  const relativeSun = Number.isFinite(sunObj?.x) && Number.isFinite(sunObj?.y)
+    ? Math.abs(sunObj.x) < 1e-3 && Math.abs(sunObj.y) < 1e-3
+    : false;
+  const sunX = Number.isFinite(sunObj?.x) ? sunObj.x + (relativeSun ? WORLD.w/2 : 0) : WORLD.w/2;
+  const sunY = Number.isFinite(sunObj?.y) ? sunObj.y + (relativeSun ? WORLD.h/2 : 0) : WORLD.h/2;
+  const sunR = Number.isFinite(sunObj?.r) ? sunObj.r : SUN.r;
+  SUN.x = sunX;
+  SUN.y = sunY;
+  SUN.r = sunR;
+
+  const sorted = [...list].sort((a, b) => (a.orbitRadius || 0) - (b.orbitRadius || 0));
+  planets.length = 0;
+  sorted.forEach((src, idx) => {
+    const orbitRadius = src.orbitRadius != null ? src.orbitRadius : Math.hypot((src.x ?? (sunX + 1)) - sunX, (src.y ?? sunY) - sunY);
+    const baseAngle = typeof src.orbitPhase === 'number'
+      ? src.orbitPhase
+      : Math.atan2((src.y ?? sunY) - sunY, (src.x ?? (sunX + orbitRadius)) - sunX);
+    const radius = src.r != null ? src.r : 60;
+    const speed = src.orbitSpeed != null ? src.orbitSpeed : 0;
+    const type = mapPlanetType(src.type);
+    const name = src.name || `Planet ${idx + 1}`;
+    const x = sunX + Math.cos(baseAngle) * orbitRadius;
+    const y = sunY + Math.sin(baseAngle) * orbitRadius;
+    planets.push({
+      id: idx,
+      name,
+      type,
+      r: radius,
+      orbitRadius,
+      angle: baseAngle,
+      speed,
+      orbitPhase: baseAngle,
+      orbitSpeed: speed,
+      x,
+      y
+    });
+  });
+
+  stations = buildStationsFromPlanets(planets);
+  markStationsInner();
+  initWarpRoutes();
+  systemConfigured = true;
+  initPlanets3D(planets, SUN);
+  if (systemReadyResolve) {
+    systemReadyResolve();
+    systemReadyResolve = null;
+  }
+}
+
+function createDefaultSystem(){
+  const NUM_PLANETS = 7;
+  const TYPES = [
+    PLANET_TYPES.VOLCANIC,
+    PLANET_TYPES.VOLCANIC,
+    PLANET_TYPES.TERRAN,
+    PLANET_TYPES.TERRAN,
+    PLANET_TYPES.BARREN,
+    PLANET_TYPES.GAS,
+    PLANET_TYPES.FROZEN
+  ];
+  const BASE_ORBIT = 7000;
+  const list = [];
+  for (let i = 0; i < NUM_PLANETS; i++) {
+    const orbitRadius = BASE_ORBIT * (i + 1);
+    const angle = Math.random() * Math.PI * 2;
+    const au = i + 1;
+    const periodHours = 24 * 365 * Math.pow(au, 1.5);
+    const speed = (2 * Math.PI) / (periodHours * 3600);
+    const r = (48 + Math.floor(Math.random() * 36)) * 3;
+    list.push({
+      name: `P-${i + 1}`,
+      type: TYPES[i],
+      r,
+      orbitRadius,
+      orbitSpeed: speed,
+      orbitPhase: angle
+    });
+  }
+  return { list, sunObj: { x: SUN.x, y: SUN.y, r: SUN.r } };
+}
+
+async function initSystem(){
+  if (USE_BAZYL_SYSTEM) {
+    try {
+      const { bazylToOurSystem } = await import('./systems/bazyl.adapter.js');
+      const res = await fetch(BAZYL_SYSTEM_PATH);
+      if (!res.ok) throw new Error(`Bazyl system fetch failed: ${res.status}`);
+      const raw = await res.json();
+      const { list, sunObj } = bazylToOurSystem(raw);
+      configureSystemFromData(list, sunObj);
+      return;
+    } catch (err) {
+      console.error('Bazyl system load failed, falling back to procedural', err);
+    }
+  }
+  const fallback = createDefaultSystem();
+  configureSystemFromData(fallback.list, fallback.sunObj);
+}
+
+initSystem();
 
 let npcs = [];
 const MISSION_NPCS = [];
@@ -1046,11 +1137,6 @@ function initNPCs(){
     spawnPolicePatrol(1,2,'outer');
   }
 }
-// Ensure Three.js modules are loaded before initializing 3D objects
-window.addEventListener('DOMContentLoaded', () => {
-  initPlanets3D(planets, SUN);
-});
-
 // =============== Bullets & effects ===============
 const bullets = [];
 const particles = [];
@@ -4492,7 +4578,8 @@ function maybeFireRockets(n, target){ /* warunkowo */ }
 
 // init
 const loadingEl = document.getElementById('loading');
-function startGame(){
+async function startGame(){
+  await systemReadyPromise;
   initStars(true);
   initNPCs();
   for(let i=0;i<120;i++) npcStep(PHYS_DT);

--- a/systems/bazyl.adapter.js
+++ b/systems/bazyl.adapter.js
@@ -1,0 +1,104 @@
+// systems/bazyl.adapter.js
+//
+// Adapter z formatu repo "bazylowybazyl/planety" na nasz format listy
+// oczekiwany przez initPlanets3D(list, sunObj).
+
+/**
+ * @param {Object} raw - Dane wczytane z repo Bazyl (JSON/JS).
+ *  Oczekiwane (elastycznie): raw.star, raw.planets[] z polami typu:
+ *   - name, radius (km?), type ("terrestrial"/"gas"/"ice"/itp.),
+ *   - orbitRadius (AU/km/…),
+ *   - orbitalPeriod (dni/sekundy/…)
+ */
+export function bazylToOurSystem(raw) {
+  const planetsSrc = Array.isArray(raw?.planets) ? raw.planets : [];
+
+  // 1) Ustal skale jednostek (dostosuj po obejrzeniu danych):
+  //    - promienie planet przeskaluj do ~[10..60] (nasz świat)
+  //    - dystans Słońce–Ziemia (1 AU) ≈ np. 3000 world units (bez wychodzenia poza WORLD)
+  const AU_TO_WORLD = 3000;
+  const KM_TO_WORLD_RADIUS = 0.01;
+  const ORBIT_SPEED_SCALE = 720; // przyspiesz okresy dla czytelnego ruchu
+
+  const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+  // 2) Mapowanie typów/kolorystyki na nasze presety
+  const typeMap = (t) => {
+    const k = (t || '').toLowerCase();
+    if (k.includes('ter') || k.includes('rock')) return 'terran';
+    if (k.includes('gas')) return 'gas';
+    if (k.includes('ice')) return 'ice';
+    if (k.includes('water')) return 'terran';
+    return 'terran';
+  };
+
+  // 3) Słońce
+  const sunRadiusWorld = clamp(
+    (raw?.star?.radiusKm || raw?.star?.radius || 300000) * KM_TO_WORLD_RADIUS * 0.1,
+    320,
+    1400
+  );
+  const sunObj = {
+    x: 0,
+    y: 0,
+    r: sunRadiusWorld,
+  };
+
+  // Pomocnicze: wyciągnij orbitę w AU lub km i przelicz
+  const orbitToWorld = (p) => {
+    if (p.orbitRadiusAU != null) return p.orbitRadiusAU * AU_TO_WORLD;
+    if (p.orbitRadiusAu != null) return p.orbitRadiusAu * AU_TO_WORLD;
+    if (p.orbitRadius != null && typeof p.orbitRadius === 'number') return p.orbitRadius * AU_TO_WORLD;
+    if (p.semiMajorAxisAU != null) return p.semiMajorAxisAU * AU_TO_WORLD;
+    if (p.orbitRadiusKm != null) return p.orbitRadiusKm * KM_TO_WORLD_RADIUS;
+    if (p.semiMajorAxisKm != null) return p.semiMajorAxisKm * KM_TO_WORLD_RADIUS;
+    return 0;
+  };
+
+  const periodToSeconds = (p) => {
+    if (p.orbitalPeriodSeconds != null) return p.orbitalPeriodSeconds;
+    if (p.orbitalPeriodDays != null) return p.orbitalPeriodDays * 24 * 3600;
+    if (p.orbitalPeriodHours != null) return p.orbitalPeriodHours * 3600;
+    if (p.orbitalPeriod != null && typeof p.orbitalPeriod === 'number') return p.orbitalPeriod;
+    return 0;
+  };
+
+  // 4) Planety → nasz format wejściowy
+  const list = planetsSrc.map((p, i) => {
+    const orbitWorld = orbitToWorld(p);
+    const radiusWorld = clamp(
+      (p.radiusKm || p.radius || 3000) * KM_TO_WORLD_RADIUS,
+      12,
+      80
+    );
+
+    const sunX = sunObj.x;
+    const sunY = sunObj.y;
+
+    const angle0 = (typeof p.orbitPhase === 'number') ? p.orbitPhase : 0;
+    const x0 = sunX + Math.cos(angle0) * orbitWorld;
+    const y0 = sunY + Math.sin(angle0) * orbitWorld;
+
+    let orbitSpeed = 0;
+    const Tsec = periodToSeconds(p);
+    if (Tsec > 0) {
+      orbitSpeed = ((2 * Math.PI) / Tsec) * ORBIT_SPEED_SCALE;
+    }
+
+    return {
+      name: p.name || `Planet ${i + 1}`,
+      type: typeMap(p.type),
+      r: radiusWorld,
+      x: x0,
+      y: y0,
+      orbitRadius: orbitWorld,
+      orbitSpeed,
+      orbitPhase: angle0,
+    };
+  });
+
+  // 5) Uzupełnij „orbitRadius” dla dwóch sąsiadujących planet (do pasa asteroid)
+  list.sort((a, b) => (a.orbitRadius || 0) - (b.orbitRadius || 0));
+
+  return { list, sunObj };
+}

--- a/systems/bazyl.system.json
+++ b/systems/bazyl.system.json
@@ -1,0 +1,64 @@
+{
+  "star": {
+    "name": "Sun",
+    "radiusKm": 695700
+  },
+  "planets": [
+    {
+      "name": "Mercury",
+      "type": "terrestrial",
+      "radiusKm": 2439.7,
+      "orbitRadiusAU": 0.387,
+      "orbitalPeriodDays": 87.97
+    },
+    {
+      "name": "Venus",
+      "type": "terrestrial",
+      "radiusKm": 6051.8,
+      "orbitRadiusAU": 0.723,
+      "orbitalPeriodDays": 224.7
+    },
+    {
+      "name": "Earth",
+      "type": "terrestrial",
+      "radiusKm": 6371,
+      "orbitRadiusAU": 1,
+      "orbitalPeriodDays": 365.256
+    },
+    {
+      "name": "Mars",
+      "type": "terrestrial",
+      "radiusKm": 3389.5,
+      "orbitRadiusAU": 1.524,
+      "orbitalPeriodDays": 686.98
+    },
+    {
+      "name": "Jupiter",
+      "type": "gas giant",
+      "radiusKm": 69911,
+      "orbitRadiusAU": 5.203,
+      "orbitalPeriodDays": 4332.59
+    },
+    {
+      "name": "Saturn",
+      "type": "gas giant",
+      "radiusKm": 58232,
+      "orbitRadiusAU": 9.537,
+      "orbitalPeriodDays": 10759.22
+    },
+    {
+      "name": "Uranus",
+      "type": "ice giant",
+      "radiusKm": 25362,
+      "orbitRadiusAU": 19.191,
+      "orbitalPeriodDays": 30688.5
+    },
+    {
+      "name": "Neptune",
+      "type": "ice giant",
+      "radiusKm": 24622,
+      "orbitRadiusAU": 30.07,
+      "orbitalPeriodDays": 60182
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an adapter and solar system data derived from bazylowybazyl/planety
- initialize planets and stations from the Bazyl dataset with a toggleable loader and procedural fallback
- support orbital motion/types in the 3D layer and tune asteroid belt density for large systems

## Testing
- node -e "import('./systems/bazyl.adapter.js').then(m=>console.log(m.bazylToOurSystem({star:{radiusKm:1}, planets:[]})))"

------
https://chatgpt.com/codex/tasks/task_b_68d9976aaad0832592d91816ca666260