### PR TITLE
Replace asteroid belt placeholder with GLTF models

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,12 +74,14 @@
   import { RenderPass }      from "three/addons/postprocessing/RenderPass.js";
   import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
   import { createShortNeedleExhaust, createWarpExhaustBlue } from "./Engineeffects.js";
+  import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
   window.THREE = THREE;
   window.EffectComposer  = EffectComposer;
   window.RenderPass      = RenderPass;
   window.UnrealBloomPass = UnrealBloomPass;
   window.createShortNeedleExhaust = createShortNeedleExhaust;
   window.createWarpExhaustBlue = createWarpExhaustBlue;
+  window.GLTFLoader = GLTFLoader;
 
 </script>
 <script src="planet3d.proc.js"></script>


### PR DESCRIPTION
## Summary
- expose Three.js GLTFLoader in the main module so the asteroid belt can load GLB assets
- rebuild AsteroidBelt3D to instance meshes from asteroidPack.glb and keep the shared renderer flow
- default the 2D overlay dots to off while preserving rotation and belt integration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da76d1a01c83259b8aca1e24d3aba2