### PR TITLE
Simplify asteroid belt setup and add GLB fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,38 +93,6 @@ const ctx = canvas.getContext('2d');
 let W = canvas.width = innerWidth, H = canvas.height = innerHeight;
 window.addEventListener('resize', ()=>{ W = canvas.width = innerWidth; H = canvas.height = innerHeight; initStars(true); });
 
-let belt3d = null;
-// === BELT 3D SETUP ===
-(function initBelt3D(){
-  function setup(){
-    if (belt3d) return;
-    if (typeof createAsteroidBelt3D !== 'function'){
-      requestAnimationFrame(setup);
-      return;
-    }
-    const glCanvas = document.createElement('canvas');
-    glCanvas.width = canvas.width;
-    glCanvas.height = canvas.height;
-    const gl = glCanvas.getContext('webgl2') || glCanvas.getContext('webgl');
-    if (!gl){
-      console.warn('Asteroid belt 3D: WebGL context unavailable.');
-      return;
-    }
-    window.__glBeltCanvas = glCanvas;
-    try {
-      belt3d = createAsteroidBelt3D(gl);
-    } catch (err){
-      console.error('Asteroid belt 3D init failed:', err);
-      belt3d = null;
-    }
-  }
-  if (document.readyState === 'complete' || document.readyState === 'interactive'){
-    requestAnimationFrame(setup);
-  } else {
-    window.addEventListener('DOMContentLoaded', setup, { once: true });
-  }
-})();
-
 const clamp = (v,a,b)=>Math.max(a,Math.min(b,v));
 const add = (a,b)=>({x:a.x+b.x,y:a.y+b.y});
 const mul = (v,s)=>({x:v.x*s,y:v.y*s});
@@ -4505,6 +4473,5 @@ function startGame(){
 }
 setTimeout(startGame, 500);
 </script>
-<script src="belt3d.js"></script>
 </body>
 </html>

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -726,6 +726,7 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
       this.canvas.height = 1024;
       this.ctx2d = this.canvas.getContext("2d");
       this.drawOverlayDots = false;
+      this.asteroids = null;
       if (typeof THREE === "undefined") return;
 
       this.scene = new THREE.Scene();
@@ -819,21 +820,16 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
             buildFromGeos(geos);
           },
           undefined,
-          (err) => console.error("GLTF asteroid load error:", err)
+          (err) => {
+            console.warn("GLTF asteroid load error, using fallback:", err);
+            const g = new THREE.IcosahedronGeometry(1, 1);
+            g.computeVertexNormals();
+            buildFromGeos([g]);
+          }
         );
       };
 
       tryLoadGLTF();
-
-      // Losowe asteroidy w jednostkach świata do rysowania bezpośrednio na canvasie 2D
-      this.asteroids = [];
-      for (let i = 0; i < 2000; i++) {
-        this.asteroids.push({
-          angle: Math.random() * TAU,
-          radius: innerRadius + Math.random() * (outerRadius - innerRadius),
-          size: 20 + Math.random() * 40,
-        });
-      }
     }
 
     render(dt) {
@@ -895,7 +891,7 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
       const width = (r2 - r1) * 0.2;
       const inner = mid - width / 2;
       const outer = mid + width / 2;
-      asteroidBelt = new AsteroidBelt3D(inner, outer);
+      asteroidBelt = new AsteroidBelt3D(inner, outer, 1800);
     }
   }
   function updatePlanets3D(dt) {


### PR DESCRIPTION
## Summary
- remove the standalone belt3d bootstrap from index.html while keeping GLTFLoader on the window
- stop generating 2D overlay dots for the asteroid belt and ensure a geometry fallback is used if the GLB fails to load
- increase the asteroid belt instancing count for a denser ring

## Testing
- npm ci
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68da8789b2548325bcb4e740f8799147