### PR TITLE
Fix bloom post-processing for shared renderer

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -391,10 +391,19 @@
         this.composer.setSize(this.canvas.width, this.canvas.height);
         const rp = new RenderPass(this.scene, this.camera);
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 1.14, 1.04, 0.0);
+        this.bloom.renderToScreen = true;
         this.composer.addPass(rp);
         this.composer.addPass(this.bloom);
       }
-      this.composer.render();
+      if (this.composer) {
+        r.autoClear = false;
+        this.composer.render();
+        r.autoClear = true;
+      } else {
+        r.autoClear = true;
+        r.render(this.scene, this.camera);
+      }
+      r.autoClear = true;
       this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
       // powiększ obraz, aby słońce wypełniało większą część canvasa
       const zoom = 1.3;
@@ -513,7 +522,6 @@
       this._renderer = null;
       this.composer = null;
       this.bloom = null;
-      this._savedAutoClear = undefined;
       this._composerWidth = 0;
       this._composerHeight = 0;
     }
@@ -535,11 +543,11 @@
 
       if (hasPP && (!this.composer || this._renderer !== r)) {
         this._renderer = r;
-        this._savedAutoClear = r.autoClear;
         this.composer = new EffectComposer(r);
         this.composer.setSize(this.canvas.width, this.canvas.height);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 0.35, 0.9, 0.0);
+        this.bloom.renderToScreen = true;
         this.composer.addPass(this.bloom);
         this._composerWidth = this.canvas.width;
         this._composerHeight = this.canvas.height;
@@ -555,15 +563,15 @@
         }
       }
 
-      const restoreAutoClear = (this._savedAutoClear !== undefined) ? this._savedAutoClear : r.autoClear;
       if (this.composer) {
         r.autoClear = false;
         this.composer.render();
-        r.autoClear = restoreAutoClear;
+        r.autoClear = true;
       } else {
+        r.autoClear = true;
         r.render(this.scene, this.camera);
-        r.autoClear = restoreAutoClear;
       }
+      r.autoClear = true;
 
       const ctx = this.ctx2d;
       ctx.clearRect(0,0,this.canvas.width,this.canvas.height);

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -699,14 +699,19 @@ if (hasPP && (!this.composer || this._renderer !== r)) {
   this.composer.setSize(this.canvas.width, this.canvas.height);
   const rp = new RenderPass(this.scene, this.camera);
   this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 1.14, 1.04, 0.0);
+  this.bloom.renderToScreen = true;
   this.composer.addPass(rp);
   this.composer.addPass(this.bloom);
 }
 if (this.composer) {
+  r.autoClear = false;
   this.composer.render();
+  r.autoClear = true;
 } else {
+  r.autoClear = true;
   r.render(this.scene, this.camera);
 }
+r.autoClear = true;
 this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
       const zoom = 1.3;
       const srcW = this.canvas.width / zoom;
@@ -823,7 +828,6 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
       this._renderer = null;
       this.composer = null;
       this.bloom = null;
-      this._savedAutoClear = undefined;
       this._composerWidth = 0;
       this._composerHeight = 0;
     }
@@ -845,11 +849,11 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
 
       if (hasPP && (!this.composer || this._renderer !== r)) {
         this._renderer = r;
-        this._savedAutoClear = r.autoClear;
         this.composer = new EffectComposer(r);
         this.composer.setSize(this.canvas.width, this.canvas.height);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 0.35, 0.9, 0.0);
+        this.bloom.renderToScreen = true;
         this.composer.addPass(this.bloom);
         this._composerWidth = this.canvas.width;
         this._composerHeight = this.canvas.height;
@@ -865,15 +869,15 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
         }
       }
 
-      const restoreAutoClear = (this._savedAutoClear !== undefined) ? this._savedAutoClear : r.autoClear;
       if (this.composer) {
         r.autoClear = false;
         this.composer.render();
-        r.autoClear = restoreAutoClear;
+        r.autoClear = true;
       } else {
+        r.autoClear = true;
         r.render(this.scene, this.camera);
-        r.autoClear = restoreAutoClear;
       }
+      r.autoClear = true;
 
       const ctx = this.ctx2d;
       ctx.clearRect(0,0,this.canvas.width,this.canvas.height);


### PR DESCRIPTION
## Summary
- ensure the UnrealBloomPass in both dev and production overlays renders to the shared WebGL canvas
- explicitly toggle renderer.autoClear around composer usage and restore it to true after each render cycle
- keep the non-composer path clearing enabled so the shared renderer output always reaches the DOM element

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68daa664478483259930444ea54338b3