### PR TITLE
Restore 3D output pass and autoClear discipline

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,15 +73,21 @@
   import { EffectComposer }  from "three/addons/postprocessing/EffectComposer.js";
   import { RenderPass }      from "three/addons/postprocessing/RenderPass.js";
   import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
+  import { ShaderPass }      from "three/addons/postprocessing/ShaderPass.js";
+  import { OutputPass }      from "three/addons/postprocessing/OutputPass.js";
+  import { CopyShader }      from "three/addons/shaders/CopyShader.js";
   import { createShortNeedleExhaust, createWarpExhaustBlue } from "./Engineeffects.js";
   import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
   window.THREE = THREE;
   window.EffectComposer  = EffectComposer;
   window.RenderPass      = RenderPass;
   window.UnrealBloomPass = UnrealBloomPass;
+  window.ShaderPass      = ShaderPass;
+  window.OutputPass      = OutputPass;
   window.createShortNeedleExhaust = createShortNeedleExhaust;
   window.createWarpExhaustBlue = createWarpExhaustBlue;
   window.GLTFLoader = GLTFLoader;
+  THREE.CopyShader = CopyShader;
 
 </script>
 <script src="planet3d.proc.js"></script>

--- a/planet3d.js
+++ b/planet3d.js
@@ -391,9 +391,19 @@
         this.composer.setSize(this.canvas.width, this.canvas.height);
         const rp = new RenderPass(this.scene, this.camera);
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 1.14, 1.04, 0.0);
-        this.bloom.renderToScreen = true;
         this.composer.addPass(rp);
         this.composer.addPass(this.bloom);
+        let finalPass = null;
+        if (typeof OutputPass !== 'undefined') {
+          finalPass = new OutputPass();
+        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
+          finalPass = new ShaderPass(THREE.CopyShader);
+          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        }
+        if (finalPass) {
+          console.debug('Final pass:', finalPass?.constructor?.name);
+          this.composer.addPass(finalPass);
+        }
       }
       if (this.composer) {
         r.autoClear = false;
@@ -547,8 +557,18 @@
         this.composer.setSize(this.canvas.width, this.canvas.height);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 0.35, 0.9, 0.0);
-        this.bloom.renderToScreen = true;
         this.composer.addPass(this.bloom);
+        let finalPass = null;
+        if (typeof OutputPass !== 'undefined') {
+          finalPass = new OutputPass();
+        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
+          finalPass = new ShaderPass(THREE.CopyShader);
+          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        }
+        if (finalPass) {
+          console.debug('Final pass:', finalPass?.constructor?.name);
+          this.composer.addPass(finalPass);
+        }
         this._composerWidth = this.canvas.width;
         this._composerHeight = this.canvas.height;
       }

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -693,26 +693,36 @@ const PLANET_FRAG = `// Terrain generation parameters
       const hasPP = (typeof EffectComposer !== 'undefined') &&
                (typeof RenderPass !== 'undefined') &&
                (typeof UnrealBloomPass !== 'undefined');
-if (hasPP && (!this.composer || this._renderer !== r)) {
-  this._renderer = r;
-  this.composer = new EffectComposer(r);
-  this.composer.setSize(this.canvas.width, this.canvas.height);
-  const rp = new RenderPass(this.scene, this.camera);
-  this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 1.14, 1.04, 0.0);
-  this.bloom.renderToScreen = true;
-  this.composer.addPass(rp);
-  this.composer.addPass(this.bloom);
-}
-if (this.composer) {
-  r.autoClear = false;
-  this.composer.render();
-  r.autoClear = true;
-} else {
-  r.autoClear = true;
-  r.render(this.scene, this.camera);
-}
-r.autoClear = true;
-this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
+      if (hasPP && (!this.composer || this._renderer !== r)) {
+        this._renderer = r;
+        this.composer = new EffectComposer(r);
+        this.composer.setSize(this.canvas.width, this.canvas.height);
+        const rp = new RenderPass(this.scene, this.camera);
+        this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 1.14, 1.04, 0.0);
+        this.composer.addPass(rp);
+        this.composer.addPass(this.bloom);
+        let finalPass = null;
+        if (typeof OutputPass !== 'undefined') {
+          finalPass = new OutputPass();
+        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
+          finalPass = new ShaderPass(THREE.CopyShader);
+          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        }
+        if (finalPass) {
+          console.debug('Final pass:', finalPass?.constructor?.name);
+          this.composer.addPass(finalPass);
+        }
+      }
+      if (this.composer) {
+        r.autoClear = false;
+        this.composer.render();
+        r.autoClear = true;
+      } else {
+        r.autoClear = true;
+        r.render(this.scene, this.camera);
+      }
+      r.autoClear = true;
+      this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
       const zoom = 1.3;
       const srcW = this.canvas.width / zoom;
       const srcH = this.canvas.height / zoom;
@@ -853,8 +863,18 @@ this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
         this.composer.setSize(this.canvas.width, this.canvas.height);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.canvas.width, this.canvas.height), 0.35, 0.9, 0.0);
-        this.bloom.renderToScreen = true;
         this.composer.addPass(this.bloom);
+        let finalPass = null;
+        if (typeof OutputPass !== 'undefined') {
+          finalPass = new OutputPass();
+        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
+          finalPass = new ShaderPass(THREE.CopyShader);
+          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        }
+        if (finalPass) {
+          console.debug('Final pass:', finalPass?.constructor?.name);
+          this.composer.addPass(finalPass);
+        }
         this._composerWidth = this.canvas.width;
         this._composerHeight = this.canvas.height;
       }

--- a/sun.html
+++ b/sun.html
@@ -32,7 +32,18 @@
       import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
       import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
       import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+      import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+      import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+      import { CopyShader } from 'three/addons/shaders/CopyShader.js';
       import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
+      window.THREE = THREE;
+      window.EffectComposer = EffectComposer;
+      window.RenderPass = RenderPass;
+      window.UnrealBloomPass = UnrealBloomPass;
+      window.ShaderPass = ShaderPass;
+      window.OutputPass = OutputPass;
+      THREE.CopyShader = CopyShader;
 
       // --- Scena / kamera / renderer ---
       const app = document.getElementById('app');
@@ -310,6 +321,17 @@
       composer.addPass(renderPass);
       const bloom = new UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), params.bloomStrength, params.bloomRadius, params.bloomThreshold);
       composer.addPass(bloom);
+      let finalPass = null;
+      if (OutputPass) {
+        finalPass = new OutputPass();
+      } else if (ShaderPass && CopyShader) {
+        finalPass = new ShaderPass(CopyShader);
+        if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+      }
+      if (finalPass) {
+        console.debug('Final pass:', finalPass?.constructor?.name);
+        composer.addPass(finalPass);
+      }
 
       // --- GUI ---
       const gui = new GUI({ title: 'Słońce — ustawienia' });
@@ -339,7 +361,9 @@
         corona.rotation.y = sun.rotation.y;
         protubGroup.rotation.y = sun.rotation.y * 0.9;
         controls.update();
+        renderer.autoClear = false;
         composer.render();
+        renderer.autoClear = true;
         requestAnimationFrame(animate);
       }
       animate();


### PR DESCRIPTION
## Summary
- add OutputPass (with CopyShader fallback) to every EffectComposer to ensure final frame output and log the active pass
- expose ShaderPass, CopyShader, and OutputPass via window in the main page and sun demo modules
- enforce renderer.autoClear toggling around composer.render invocations to keep the shared buffer clean

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68daadb68158832596dd69b1f196556b