### PR TITLE
Fix postprocessing globals and composer final pass

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,10 +84,10 @@
   window.UnrealBloomPass = UnrealBloomPass;
   window.ShaderPass      = ShaderPass;
   window.OutputPass      = OutputPass;
+  window.CopyShader      = CopyShader;
   window.createShortNeedleExhaust = createShortNeedleExhaust;
   window.createWarpExhaustBlue = createWarpExhaustBlue;
   window.GLTFLoader = GLTFLoader;
-  THREE.CopyShader = CopyShader;
 
 </script>
 <script src="planet3d.proc.js"></script>

--- a/planet3d.js
+++ b/planet3d.js
@@ -396,9 +396,8 @@
         let finalPass = null;
         if (typeof OutputPass !== 'undefined') {
           finalPass = new OutputPass();
-        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
-          finalPass = new ShaderPass(THREE.CopyShader);
-          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        } else if (typeof ShaderPass !== 'undefined' && typeof CopyShader !== 'undefined') {
+          finalPass = new ShaderPass(CopyShader);
         }
         if (finalPass) {
           console.debug('Final pass:', finalPass?.constructor?.name);
@@ -561,9 +560,8 @@
         let finalPass = null;
         if (typeof OutputPass !== 'undefined') {
           finalPass = new OutputPass();
-        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
-          finalPass = new ShaderPass(THREE.CopyShader);
-          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        } else if (typeof ShaderPass !== 'undefined' && typeof CopyShader !== 'undefined') {
+          finalPass = new ShaderPass(CopyShader);
         }
         if (finalPass) {
           console.debug('Final pass:', finalPass?.constructor?.name);

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -704,9 +704,8 @@ const PLANET_FRAG = `// Terrain generation parameters
         let finalPass = null;
         if (typeof OutputPass !== 'undefined') {
           finalPass = new OutputPass();
-        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
-          finalPass = new ShaderPass(THREE.CopyShader);
-          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        } else if (typeof ShaderPass !== 'undefined' && typeof CopyShader !== 'undefined') {
+          finalPass = new ShaderPass(CopyShader);
         }
         if (finalPass) {
           console.debug('Final pass:', finalPass?.constructor?.name);
@@ -867,9 +866,8 @@ const PLANET_FRAG = `// Terrain generation parameters
         let finalPass = null;
         if (typeof OutputPass !== 'undefined') {
           finalPass = new OutputPass();
-        } else if (typeof ShaderPass !== 'undefined' && typeof THREE !== 'undefined' && THREE && THREE.CopyShader) {
-          finalPass = new ShaderPass(THREE.CopyShader);
-          if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
+        } else if (typeof ShaderPass !== 'undefined' && typeof CopyShader !== 'undefined') {
+          finalPass = new ShaderPass(CopyShader);
         }
         if (finalPass) {
           console.debug('Final pass:', finalPass?.constructor?.name);

--- a/sun.html
+++ b/sun.html
@@ -43,7 +43,7 @@
       window.UnrealBloomPass = UnrealBloomPass;
       window.ShaderPass = ShaderPass;
       window.OutputPass = OutputPass;
-      THREE.CopyShader = CopyShader;
+      window.CopyShader = CopyShader;
 
       // --- Scena / kamera / renderer ---
       const app = document.getElementById('app');
@@ -326,7 +326,6 @@
         finalPass = new OutputPass();
       } else if (ShaderPass && CopyShader) {
         finalPass = new ShaderPass(CopyShader);
-        if (finalPass.renderToScreen !== undefined) finalPass.renderToScreen = true;
       }
       if (finalPass) {
         console.debug('Final pass:', finalPass?.constructor?.name);


### PR DESCRIPTION
## Summary
- expose CopyShader as a standalone global so THREE remains immutable
- update planet postprocessing to append a final Output/Copy shader pass without renderToScreen usage
- align the sun demo with the new global CopyShader export

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dab7d372cc8325ad7a019ebb7f857c