### PR TITLE
Disable postprocessing fallback to restore star transparency

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -1,5 +1,6 @@
 (function () {
   // ======= USTAWIENIA / NARZĘDZIA =======
+  const USE_PP = false; // tymczasowo
   const planets = [];
   let sun = null;
   let asteroidBelt = null;
@@ -386,18 +387,19 @@
       r.toneMappingExposure = 1.1;
       r.outputColorSpace = THREE.SRGBColorSpace;
 
-      const hasPostProcessing =
+      const hasPP =
+        USE_PP &&
         typeof EffectComposer !== "undefined" &&
         typeof RenderPass !== "undefined" &&
         typeof UnrealBloomPass !== "undefined";
 
-      if (!hasPostProcessing) {
+      if (!hasPP) {
         this.composer = null;
         this._renderer = null;
         this.bloom = null;
       }
 
-      if (hasPostProcessing && (!this.composer || this._renderer !== r)) {
+      if (hasPP && (!this.composer || this._renderer !== r)) {
         this._renderer = r;
         this.composer = new EffectComposer(r);
         this.composer.setSize(this.canvas.width, this.canvas.height);
@@ -573,7 +575,8 @@
       r.toneMappingExposure = 1.0;
       r.outputColorSpace = THREE.SRGBColorSpace;
 
-      const hasPP = (typeof EffectComposer !== 'undefined') &&
+      const hasPP = USE_PP &&
+                    (typeof EffectComposer !== 'undefined') &&
                     (typeof RenderPass !== 'undefined') &&
                     (typeof UnrealBloomPass !== 'undefined');
 


### PR DESCRIPTION
## Summary
- add a toggle to disable Three.js post-processing until transparency-safe final pass is available
- fall back to direct renderer output for Sun and asteroid belt canvases so alpha is preserved

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dac383629c832582afc535ba05a55e