### PR TITLE
Disable postprocessing fallback in production renderer

### DIFF
--- a/planet3d.js
+++ b/planet3d.js
@@ -1,5 +1,6 @@
 (function () {
   // ======= USTAWIENIA / NARZĘDZIA =======
+  const USE_PP = false; // tymczasowo
   const planets = [];
   let sun = null;
   let asteroidBelt = null;
@@ -386,18 +387,19 @@
       r.toneMappingExposure = 1.1;
       r.outputColorSpace = THREE.SRGBColorSpace;
 
-      const hasPostProcessing =
+      const hasPP =
+        USE_PP &&
         typeof EffectComposer !== "undefined" &&
         typeof RenderPass !== "undefined" &&
         typeof UnrealBloomPass !== "undefined";
 
-      if (!hasPostProcessing) {
+      if (!hasPP) {
         this.composer = null;
         this._renderer = null;
         this.bloom = null;
       }
 
-      if (hasPostProcessing && (!this.composer || this._renderer !== r)) {
+      if (hasPP && (!this.composer || this._renderer !== r)) {
         this._renderer = r;
         this.composer = new EffectComposer(r);
         this.composer.setSize(this.canvas.width, this.canvas.height);
@@ -573,7 +575,8 @@
       r.toneMappingExposure = 1.0;
       r.outputColorSpace = THREE.SRGBColorSpace;
 
-      const hasPP = (typeof EffectComposer !== 'undefined') &&
+      const hasPP = USE_PP &&
+                    (typeof EffectComposer !== 'undefined') &&
                     (typeof RenderPass !== 'undefined') &&
                     (typeof UnrealBloomPass !== 'undefined');
 

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -1,4 +1,6 @@
 
+const USE_PP = false; // tymczasowo wyłącz postprocessing, aby zachować pełną przezroczystość tła
+
 const NOISE_FUNCTIONS = `const float PI = 3.14159265;
 
     //	Simplex 3D Noise 
@@ -690,9 +692,15 @@ const PLANET_FRAG = `// Terrain generation parameters
       r.toneMapping = THREE.ACESFilmicToneMapping;
       r.toneMappingExposure = 1.1;
       r.outputColorSpace = THREE.SRGBColorSpace;
-      const hasPP = (typeof EffectComposer !== 'undefined') &&
+      const hasPP = USE_PP &&
+               (typeof EffectComposer !== 'undefined') &&
                (typeof RenderPass !== 'undefined') &&
                (typeof UnrealBloomPass !== 'undefined');
+      if (!hasPP && this.composer) {
+        this.composer = null;
+        this._renderer = null;
+        this.bloom = null;
+      }
       if (hasPP && (!this.composer || this._renderer !== r)) {
         this._renderer = r;
         this.composer = new EffectComposer(r);
@@ -853,9 +861,18 @@ const PLANET_FRAG = `// Terrain generation parameters
       r.toneMappingExposure = 1.0;
       r.outputColorSpace = THREE.SRGBColorSpace;
 
-      const hasPP = (typeof EffectComposer !== 'undefined') &&
+      const hasPP = USE_PP &&
+                    (typeof EffectComposer !== 'undefined') &&
                     (typeof RenderPass !== 'undefined') &&
                     (typeof UnrealBloomPass !== 'undefined');
+
+      if (!hasPP && this.composer) {
+        this.composer = null;
+        this._renderer = null;
+        this.bloom = null;
+        this._composerWidth = 0;
+        this._composerHeight = 0;
+      }
 
       if (hasPP && (!this.composer || this._renderer !== r)) {
         this._renderer = r;


### PR DESCRIPTION
## Summary
- disable Three.js postprocessing in the production planet renderer so transparency is preserved
- reset cached composer state when postprocessing is disabled to avoid stale bloom usage

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dac383629c832582afc535ba05a55e