### PR TITLE
Add sun corona rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,7 +669,21 @@ function initStars(reset=false){
 }
 
 // =============== Słońce, planety i stacje ===============
-const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200 };
+const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200,
+  color: {
+    core:  '#ffe88a',   // jasno-żółty rdzeń
+    mid:   '#ffbe3b',   // pomarańcz-żółć
+    rim:   '#ff8c1a'    // ciepła krawędź tarczy
+  },
+  corona: {
+    rays: 72,           // ile „igieł”
+    jitter: 0.35,       // nieregularność
+    length: 0.85,       // długość korony w promieniach R
+    pulse: 0.22,        // amplituda pulsu
+    haze:  2.8          // rozmiar miękkiej poświaty (×R)
+  },
+  seed: 93731
+};
 
 const PLANET_TYPES = {
   TERRAN: 'terran',
@@ -3335,6 +3349,87 @@ function glowCircle(ctx, x, y, r, color){
   ctx.restore();
 }
 
+function drawSunWithCorona(ctx, cam, t) {
+  const s = worldToScreen(SUN.x, SUN.y, cam);
+  const R = SUN.r * camera.zoom;
+
+  ctx.save();
+  ctx.translate(s.x, s.y);
+
+  // --- miękka poświata daleko w tle (nebula-like) ---
+  ctx.globalCompositeOperation = 'lighter';
+  const hazeR = R * SUN.corona.haze;
+  const gH = ctx.createRadialGradient(0,0, R*0.6, 0,0, hazeR);
+  gH.addColorStop(0, 'rgba(255,220,120,0.25)');
+  gH.addColorStop(1, 'rgba(50,80,140,0.00)');
+  ctx.fillStyle = gH;
+  ctx.beginPath(); ctx.arc(0,0,hazeR,0,Math.PI*2); ctx.fill();
+
+  // --- korona: promieniste igły z lekkim szumem i pulsem ---
+  const rays = SUN.corona.rays | 0;
+  const baseLen = R * (1.0 + SUN.corona.length);
+  const pulse = 1 + SUN.corona.pulse * Math.sin(t*1.6);
+  const jitterAmp = SUN.corona.jitter;
+
+  // deterministyczny „szum” bez biblioteki
+  function n1(i, k=1) {
+    const x = Math.sin((i*374761.0 + SUN.seed*1.123 + k)*0.0000131) * 43758.5453;
+    return x - Math.floor(x);
+  }
+
+  ctx.beginPath();
+  for (let i=0;i<rays;i++){
+    const a = (i / rays) * Math.PI*2;
+    const w = (Math.PI*2 / rays) * (0.6 + n1(i,2)*0.6);  // szerokość klina
+    const j = (n1(i) - 0.5) * 2 * jitterAmp;
+    const len = baseLen * (0.82 + 0.18*n1(i,3)) * pulse;
+    const r1 = R * (1.02 + 0.03*n1(i,4));
+    const r2 = len * (1 + j);
+
+    const aL = a - w*0.5, aR = a + w*0.5;
+    // mały klin (trójkąt) – od krawędzi tarczy na zewnątrz
+    ctx.moveTo(Math.cos(aL)*r1, Math.sin(aL)*r1);
+    ctx.lineTo(Math.cos(a)*r2,  Math.sin(a)*r2);
+    ctx.lineTo(Math.cos(aR)*r1, Math.sin(aR)*r1);
+  }
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(255,210,120,0.25)';
+  ctx.shadowColor = 'rgba(255,235,170,0.9)';
+  ctx.shadowBlur = Math.max(6, R*0.22);
+  ctx.fill();
+
+  // --- obwód korony (fresnel) ---
+  const fresR = R * (1.2 + 0.06*Math.sin(t*1.1));
+  const gF = ctx.createRadialGradient(0,0, fresR*0.7, 0,0, fresR);
+  gF.addColorStop(0, 'rgba(255,240,180,0)');
+  gF.addColorStop(1, 'rgba(255,235,170,0.32)');
+  ctx.fillStyle = gF;
+  ctx.beginPath(); ctx.arc(0,0, fresR, 0, Math.PI*2); ctx.fill();
+
+  // --- tarcza gwiazdy (żółta z „rimem”) ---
+  const g = ctx.createRadialGradient(0,0, R*0.1, 0,0, R);
+  g.addColorStop(0, SUN.color.core);
+  g.addColorStop(0.55, SUN.color.mid);
+  g.addColorStop(1, SUN.color.rim);
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.fillStyle = g;
+  ctx.beginPath(); ctx.arc(0,0,R,0,Math.PI*2); ctx.fill();
+
+  // delikatne „plamy” (granulacja) — kilka półprzezroczystych kół
+  ctx.globalCompositeOperation = 'multiply';
+  ctx.fillStyle = 'rgba(200,90,0,0.06)';
+  for(let i=0;i<8;i++){
+    const a = (i*0.79 + t*0.15) % (Math.PI*2);
+    const rr = R*(0.12 + 0.15*n1(i,5));
+    const d  = R*(0.15 + 0.55*n1(i,6));
+    ctx.beginPath();
+    ctx.arc(Math.cos(a)*d, Math.sin(a)*d, rr, 0, Math.PI*2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
 function drawStationVFX(ctx, st, x, y, r, t){
   ctx.save();
   ctx.translate(x, y);
@@ -3596,8 +3691,8 @@ function render(alpha, frameDt){
   canvas.style.cursor = 'default';
   // Interpolacja stanu
   const interpPos = {
-    x: prevState.pos.x*(1-alpha) + ship.pos.x*alpha,
-    y: prevState.pos.y*(1-alpha) + ship.pos.y*alpha
+    x: prevState.pos.x + (ship.pos.x - prevState.pos.x) * alpha,
+    y: prevState.pos.y + (ship.pos.y - prevState.pos.y) * alpha
   };
   const interpAngle = prevState.angle*(1-alpha) + ship.angle*alpha;
   const interpTurretAngle = interpAngleShort(prevState.turretAngle, ship.turret.angle, alpha);
@@ -3624,6 +3719,9 @@ function render(alpha, frameDt){
 
   // Gwiazdy (proceduralne kafelki na całej mapie)
   drawStars(cam);
+
+  // ★ SŁOŃCE Z KORONĄ
+  drawSunWithCorona(ctx, cam, vfxTime);
 
   // scan waves
   for(const w of scanWaves){


### PR DESCRIPTION
## Summary
- extend the SUN configuration with a warm color palette and deterministic seed
- add a drawSunWithCorona helper to render the star disc, rays, and haze on the 2D canvas
- invoke the new sun renderer in the main render loop before drawing other world elements

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68dac86b2cb083258872c369e4baaa98