### PR TITLE
Normalize asteroid belt geometries when loading GLTF

### DIFF
--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -830,6 +830,10 @@ const PLANET_FRAG = `// Terrain generation parameters
               if (o.isMesh && o.geometry) {
                 const g = o.geometry.clone();
                 g.computeVertexNormals();
+                g.computeBoundingSphere();
+                const r = g.boundingSphere?.radius || 1;
+                if (r > 0) g.scale(1 / r, 1 / r, 1 / r);
+                g.center?.();
                 geos.push(g);
               }
             });


### PR DESCRIPTION
## Summary
- normalize asteroid geometries from the GLTF pack so each instanced mesh starts at unit scale before random scaling

## Testing
- npm ci
- npm run start


------
https://chatgpt.com/codex/tasks/task_b_68dacdac1fa48325b4b9c11995f7b9da