### PR TITLE
fix(planets): render asteroid belt in asset renderer frustum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 node_modules
+
+# do not commit binaries via PR
+assets/planety/**/*.psd
+planets/**
+*.glb
+*.jpg
+*.png
+*.exr
+

--- a/assets/readme.md
+++ b/assets/readme.md
@@ -1,1 +1,6 @@
 
+
+## Planet assets (Solar System)
+Renderer `planet3d.assets.js` używa tekstur z `assets/planety/solar/*` (kolor, normal, chmury) oraz uzupełniających z
+`assets/planety/images/*` (np. `earth_specularmap.jpg`, `venus_atmosphere.jpg`, `uranus_ring.png`).
+Nie commitujemy nowych binariów w PR – zmiany tylko w kodzie/konfiguracji.

--- a/index.html
+++ b/index.html
@@ -90,7 +90,8 @@
   THREE.CopyShader = CopyShader;
 
 </script>
-<script src="planet3d.proc.js"></script>
+<!-- przełącznik: aktywuj assetowy renderer planet -->
+<script src="planet3d.assets.js"></script>
 
 <script>
 // =============== Canvas & utils ===============
@@ -693,7 +694,29 @@ const PLANET_TYPES = {
   BARREN: 'barren'
 };
 
-const PLANET_DATA = (() => {
+// --- Tryb układu Słonecznego (param z URL: ?solar=1) ---
+const USE_SOLAR = new URLSearchParams(location.search).has('solar');
+
+function makeSolarPlanets() {
+  // Skala: 1 AU ≈ 3000 jednostek świata (Neptun ~ 90k, mieści się w WORLD)
+  const AU = 3000;
+  const rand = () => Math.random() * Math.PI * 2;
+  const P = [];
+  // r – promień planety w logice gry (48..~160) wpływa na rozmiar renderu 3D i orbity stacji
+  P.push({ id:'mercury', name:'Mercury', r:  44, orbitRadius: 0.39*AU, angle: rand(), speed: 0 });
+  P.push({ id:'venus',   name:'Venus',   r:  60, orbitRadius: 0.72*AU, angle: rand(), speed: 0 });
+  P.push({ id:'earth',   name:'Earth',   r:  64, orbitRadius: 1.00*AU, angle: rand(), speed: 0 });
+  P.push({ id:'mars',    name:'Mars',    r:  54, orbitRadius: 1.52*AU, angle: rand(), speed: 0 });
+  P.push({ id:'jupiter', name:'Jupiter', r: 160, orbitRadius: 5.20*AU, angle: rand(), speed: 0 });
+  P.push({ id:'saturn',  name:'Saturn',  r: 140, orbitRadius: 9.58*AU, angle: rand(), speed: 0 });
+  P.push({ id:'uranus',  name:'Uranus',  r: 108, orbitRadius:19.20*AU, angle: rand(), speed: 0 });
+  P.push({ id:'neptune', name:'Neptune', r: 104, orbitRadius:30.00*AU, angle: rand(), speed: 0 });
+  // Opcjonalnie: Pluton (komentuj/odkomentuj)
+  // P.push({ id:'pluto',   name:'Pluto',   r:  30, orbitRadius:39.50*AU, angle: rand(), speed: 0 });
+  return P;
+}
+
+function makeProceduralPlanets() {
   const NUM_PLANETS = 7;
   const TYPES = [
     PLANET_TYPES.VOLCANIC,
@@ -717,7 +740,9 @@ const PLANET_DATA = (() => {
     list.push({ id: i, orbitRadius, angle, speed, r, type: TYPES[i], x: 0, y: 0 });
   }
   return list;
-})();
+}
+
+const PLANET_DATA = USE_SOLAR ? makeSolarPlanets() : makeProceduralPlanets();
 
 let planets = PLANET_DATA.map(p => {
   p.x = SUN.x + Math.cos(p.angle) * p.orbitRadius;

--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -1,0 +1,290 @@
+// planet3d.assets.js
+(function () {
+  // ======= WSPÓŁDZIELONY RENDERER (kopiuj z proc, drobna adaptacja) =======
+  let sharedRenderer = null;
+  let rendererWidth = 0, rendererHeight = 0;
+  function getSharedRenderer(width = 256, height = 256) {
+    if (typeof THREE === "undefined") return null;
+    if (!sharedRenderer) {
+      sharedRenderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
+      sharedRenderer.setClearColor(0x000000, 0);
+      sharedRenderer.outputColorSpace = THREE.SRGBColorSpace;
+    }
+    if (rendererWidth !== width || rendererHeight !== height) {
+      sharedRenderer.setSize(width, height, false);
+      rendererWidth = width; rendererHeight = height;
+    }
+    return sharedRenderer;
+  }
+
+  // ======= MAPOWANIE TEKSTUR (tylko ścieżki tekstowe – zero binarek w PR) =======
+  const TEX = {
+    mercury: { color: 'assets/planety/solar/mercury/mercury_color.jpg', normal: 'assets/planety/solar/mercury/mercury_normal.jpg' },
+    venus:   { color: 'assets/planety/solar/venus/venus_color.jpg',   bump:   'assets/planety/images/venusbump.jpg',
+               atmo:  'assets/planety/images/venus_atmosphere.jpg' },
+    earth:   { color: 'assets/planety/solar/earth/earth_color.jpg',   normal: 'assets/planety/solar/earth/earth_normal.jpg',
+               spec:  'assets/planety/images/earth_specularmap.jpg',   night:  'assets/planety/images/earth_nightmap.jpg',
+               clouds:'assets/planety/solar/earth/earth_clouds.jpg' },
+    mars:    { color: 'assets/planety/solar/mars/mars_color.jpg',     bump:   'assets/planety/images/marsbump.jpg' },
+    jupiter: { color: 'assets/planety/solar/jupiter/jupiter_color.jpg' },
+    saturn:  { color: 'assets/planety/solar/saturn/saturn_color.jpg', ring:   'assets/planety/solar/saturn/rings_alpha.png' },
+    uranus:  { color: 'assets/planety/solar/uranus/uranus_color.jpg', ring:   'assets/planety/images/uranus_ring.png' },
+    neptune: { color: 'assets/planety/solar/neptune/neptune_color.jpg' },
+    pluto:   { color: 'assets/planety/images/plutomap.jpg',           bump:   'assets/planety/images/plutobump2k.jpg' }
+  };
+
+  const _planets = [];
+  let sun = null;
+  let asteroidBelt = null;
+  const TAU = Math.PI * 2;
+
+  // ======= PLANETA Z TEKSTUR =======
+  class AssetPlanet3D {
+    constructor(worldX, worldY, pixelSize, opts = {}) {
+      this.x = worldX; this.y = worldY;
+      this.size = pixelSize || 64;
+
+      this.canvas = document.createElement("canvas");
+      this.canvas.width = 256; this.canvas.height = 256;
+      this.ctx2d = this.canvas.getContext("2d");
+
+      if (typeof THREE === "undefined") return;
+
+      this.scene = new THREE.Scene();
+      this.camera = new THREE.PerspectiveCamera(45, 1, 0.1, 1000);
+      this.camera.position.z = 3;
+
+      const geom = new THREE.SphereGeometry(1, 96, 64);
+      const loader = new THREE.TextureLoader();
+      const name = (opts.name || opts.id || "").toLowerCase();
+      const tex = TEX[name] || {};
+
+      const tryTex = (p) => (p ? loader.load(p) : null);
+
+      const matParams = {};
+      if (tex.color)   matParams.map        = tryTex(tex.color);
+      if (tex.normal)  matParams.normalMap  = tryTex(tex.normal);
+      if (tex.bump)   { matParams.bumpMap   = tryTex(tex.bump);   matParams.bumpScale = 0.6; }
+      if (tex.spec)    matParams.specularMap= tryTex(tex.spec);
+
+      // Phong bo ładnie działa z mapami
+      this.material = new THREE.MeshPhongMaterial(matParams);
+      const light = new THREE.DirectionalLight(0xffffff, 1.0);
+      light.position.set(2, 1, 2);
+      this.scene.add(light);
+
+      this.mesh = new THREE.Mesh(geom, this.material);
+      this.scene.add(this.mesh);
+
+      // Chmury Ziemi (jeśli dostępne)
+      if (name === 'earth' && tex.clouds) {
+        const clouds = new THREE.Mesh(
+          new THREE.SphereGeometry(1.008, 64, 48),
+          new THREE.MeshPhongMaterial({ map: tryTex(tex.clouds), transparent: true, depthWrite: false })
+        );
+        this.scene.add(clouds);
+        this.clouds = clouds;
+      }
+
+      // Pierścienie Saturn/Uran
+      if (tex.ring) {
+        const ringTex = tryTex(tex.ring);
+        const ringGeo = new THREE.RingGeometry(1.35, 2.4, 256, 1);
+        const ringMat = new THREE.MeshBasicMaterial({ map: ringTex, transparent: true, side: THREE.DoubleSide });
+        const ring = new THREE.Mesh(ringGeo, ringMat);
+        ring.rotation.x = Math.PI / 2;
+        this.scene.add(ring);
+        this.ring = ring;
+      }
+
+      // delikatny obrót
+      this.spin = 0.04 + Math.random() * 0.06;
+    }
+
+    render(dt) {
+      if (!this.scene || !this.camera) return;
+      this.mesh.rotation.y += this.spin * dt;
+      if (this.clouds) this.clouds.rotation.y += this.spin * dt * 1.3;
+
+      const r = getSharedRenderer(this.canvas.width, this.canvas.height);
+      if (!r) return;
+      r.setClearColor(0x000000, 0);
+      r.render(this.scene, this.camera);
+
+      // skopiuj piksele do prywatnego canvasa 2D
+      this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
+      this.ctx2d.drawImage(r.domElement, 0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    draw(ctx, cam) {
+      const s = worldToScreen(this.x, this.y, cam);
+      const size = this.size * cam.zoom;
+      ctx.drawImage(this.canvas, s.x - size/2, s.y - size/2, size, size);
+    }
+  }
+
+  // ======= Słońce (zachowujemy prosty shaderowy wygląd z proc lub teksturę) =======
+  class Sun3D {
+    constructor(pixelSize) {
+      this.x = 0; this.y = 0; this.size = pixelSize || 512;
+      this.canvas = document.createElement('canvas');
+      this.canvas.width = 256; this.canvas.height = 256;
+      this.ctx2d = this.canvas.getContext('2d');
+
+      if (typeof THREE === "undefined") return;
+      this.scene = new THREE.Scene();
+      this.camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+      this.camera.position.z = 3;
+
+      const loader = new THREE.TextureLoader();
+      const tex = loader.load('assets/planety/solar/sun/sun_color.jpg');
+      const mat = new THREE.MeshBasicMaterial({ map: tex });
+      const mesh = new THREE.Mesh(new THREE.SphereGeometry(1.0, 128, 96), mat);
+      this.scene.add(mesh);
+      this.mesh = mesh;
+    }
+    render(dt){
+      if (!this.scene || !this.camera) return;
+      this.mesh.rotation.y += 0.02*dt;
+
+      const r = getSharedRenderer(this.canvas.width, this.canvas.height);
+      if(!r) return;
+      r.setClearColor(0x000000, 0);
+      r.render(this.scene, this.camera);
+
+      this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
+      this.ctx2d.drawImage(r.domElement, 0, 0, this.canvas.width, this.canvas.height);
+    }
+    draw(ctx, cam){
+      const s = worldToScreen(this.x, this.y, cam);
+      const size = this.size * cam.zoom;
+      ctx.drawImage(this.canvas, s.x - size/2, s.y - size/2, size, size);
+    }
+  }
+
+  // ======= Pas asteroid – kopiuj 1:1 z proceduralnego pliku (geometria instancjonowana) =======
+  // UPROSZCZENIE: użyjemy istniejącego loadera GLTF i rysunku jak w proc.
+  class AsteroidBelt3D {
+    constructor(innerRadius, outerRadius, count = 2500) {
+      this.size = outerRadius * 2;
+      this.canvas = document.createElement('canvas');
+      this.canvas.width = 1024; this.canvas.height = 1024;
+      this.ctx2d = this.canvas.getContext('2d');
+
+      if (typeof THREE === 'undefined') return;
+      this.scene = new THREE.Scene();
+      this.camera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
+      this.camera.position.set(0, 0.6, 4.2);
+      this.camera.lookAt(0, 0, 0);
+
+      // Normalizujemy pozycje do niewielkiego torusa, aby mieściły się w ściętym stożku kamery.
+      const localInnerRadius = 1.25;
+      const localOuterRadius = 2.35;
+      const worldSpan = Math.max(outerRadius - innerRadius, 1e-3);
+      const radiusScale = (localOuterRadius - localInnerRadius) / worldSpan;
+      const halfThickness = (localOuterRadius - localInnerRadius) * 0.1;
+
+      // Ładowanie paczki asteroid z assets (już w repo)
+      const tryLoadGLTF = () => {
+        const Loader = (typeof window !== 'undefined') && window.GLTFLoader;
+        if (!Loader) { requestAnimationFrame(tryLoadGLTF); return; }
+        const loader = new Loader();
+        loader.load(
+          'assets/planety/asteroids/asteroidPack.glb',
+          (gltf) => {
+            const geos = [];
+            gltf.scene.traverse((o) => {
+              if (o.isMesh && o.geometry) {
+                geos.push(o.geometry.clone());
+              }
+            });
+            if (!geos.length) return;
+            const mat = new THREE.MeshStandardMaterial({ color: 0xc0c0c0, roughness: 1.0, metalness: 0.0 });
+            const imesh = new THREE.InstancedMesh(geos[0], mat, count);
+            const m = new THREE.Matrix4();
+            const rotM = new THREE.Matrix4();
+            const scaleM = new THREE.Matrix4();
+            const euler = new THREE.Euler();
+            for (let i = 0; i < count; i++) {
+              // losowa pozycja w torusie, znormalizowana do lokalnych jednostek sceny
+              const a = Math.random() * TAU;
+              const worldRadius = innerRadius + Math.random() * worldSpan;
+              const localRadius = localInnerRadius + (worldRadius - innerRadius) * radiusScale;
+              const z = (Math.random() - 0.5) * halfThickness * 2;
+              const x = Math.cos(a) * localRadius;
+              const y = Math.sin(a) * localRadius;
+              const s = 0.018 + Math.random() * 0.045;
+              m.makeTranslation(x, y, z);
+              euler.set(Math.random() * TAU, Math.random() * TAU, Math.random() * TAU);
+              rotM.makeRotationFromEuler(euler);
+              scaleM.makeScale(s, s, s);
+              m.multiply(rotM); m.multiply(scaleM);
+              imesh.setMatrixAt(i, m);
+            }
+            imesh.instanceMatrix.needsUpdate = true;
+            this.scene.add(imesh);
+          }
+        );
+      };
+      tryLoadGLTF();
+
+      const light = new THREE.DirectionalLight(0xffffff, 1.0);
+      light.position.set(2, 2, 3);
+      this.scene.add(light);
+    }
+
+    render(dt) {
+      const r = getSharedRenderer(this.canvas.width, this.canvas.height);
+      if (!r || !this.scene || !this.camera) return;
+      r.setClearColor(0x000000, 0);
+      r.render(this.scene, this.camera);
+      this.ctx2d.clearRect(0,0,this.canvas.width,this.canvas.height);
+      this.ctx2d.drawImage(r.domElement, 0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    draw(ctx, cam) {
+      const s = worldToScreen(sun?.x || 0, sun?.y || 0, cam);
+      const size = this.size * cam.zoom;
+      ctx.drawImage(this.canvas, s.x - size/2, s.y - size/2, size, size);
+    }
+  }
+
+  // ======= API zgodne z proceduralnym rendererem =======
+  window.initPlanets3D = function initPlanets3D(list, sunObj) {
+    _planets.length = 0;
+    for (const s of list) {
+      const size = (s.r || 30) * 2.0;
+      const planet = new AssetPlanet3D(s.x, s.y, size, { name: s.name || s.id || null });
+      _planets.push(planet);
+    }
+
+    if (sunObj) {
+      sun = new Sun3D((sunObj.r || 200) * 2.5);
+      sun.x = sunObj.x; sun.y = sunObj.y;
+    }
+
+    // Pas asteroid między Marsem a Jowiszem (skalowany z istniejących orbit)
+    if (list && list.length >= 5 && list[2].orbitRadius && list[3].orbitRadius) {
+      const r1 = list[2].orbitRadius, r2 = list[3].orbitRadius;
+      const inner = r1 + 0.25*(r2 - r1);
+      const outer = r1 + 0.55*(r2 - r1);
+      asteroidBelt = new AsteroidBelt3D(inner, outer, 2200);
+    } else {
+      asteroidBelt = null;
+    }
+  };
+
+  window.updatePlanets3D = function updatePlanets3D(dt) {
+    if (sun) sun.render(dt);
+    if (asteroidBelt) asteroidBelt.render(dt);
+    for (const p of _planets) p.render(dt);
+  };
+
+  window.drawPlanets3D = function drawPlanets3D(ctx, cam) {
+    if (asteroidBelt) asteroidBelt.draw(ctx, cam);
+    for (const p of _planets) p.draw(ctx, cam);
+    if (sun) sun.draw(ctx, cam);
+  };
+
+  window.getSharedRenderer = getSharedRenderer;
+})();


### PR DESCRIPTION
## Summary
- add asset-based planet renderer that reuses existing textures and GLTF asteroid pack while sharing the WebGL renderer
- allow opting into a Solar System layout via ?solar=1 and keep procedural fallback
- document Solar System textures and tighten .gitignore against binary assets
- normalize asteroid belt instancing so the asset renderer stays within the camera frustum

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68dc411724988325afa2dd41ec319d42