### PR TITLE
Fix Three.js shader exposure and guard 3D render calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,8 @@
   window.createShortNeedleExhaust = createShortNeedleExhaust;
   window.createWarpExhaustBlue = createWarpExhaustBlue;
   window.GLTFLoader = GLTFLoader;
-  THREE.CopyShader = CopyShader;
+  // nie modyfikujemy namespace'u modułu:
+  window.CopyShader = CopyShader;
 
 </script>
 <!-- przełącznik: aktywuj assetowy renderer planet -->
@@ -3740,7 +3741,7 @@ function render(alpha, frameDt){
 
   // Czyścimy ekran
   ctx.clearRect(0,0,W,H);
-  updatePlanets3D(frameDt);
+  if (window.updatePlanets3D) updatePlanets3D(frameDt);
 
   // Gwiazdy (proceduralne kafelki na całej mapie)
   drawStars(cam);
@@ -3756,7 +3757,7 @@ function render(alpha, frameDt){
     ctx.beginPath(); ctx.arc(s.x, s.y, w.r * camera.zoom, 0, Math.PI*2); ctx.stroke();
   }
 
-  drawPlanets3D(ctx, cam);
+  if (window.drawPlanets3D)   drawPlanets3D(ctx, cam);
 
   // drogi między stacjami
   const drawn = new Set();

--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -48,7 +48,7 @@
       this.canvas.width = 256; this.canvas.height = 256;
       this.ctx2d = this.canvas.getContext("2d");
       // Zapisz nazwę i odłóż tworzenie sceny do chwili, gdy THREE będzie gotowe.
-      this._name = (opts.name || opts.id || "").toLowerCase();
+      this._name = String((opts && (opts.name ?? opts.id)) ?? "").toLowerCase();
       this._needsInit = true;
       this.spin = 0.04 + Math.random() * 0.06;
     }


### PR DESCRIPTION
## Summary
- expose CopyShader on window without mutating the THREE module namespace
- make asset planet name resolution work with numeric ids
- guard the render loop against missing 3D update/draw hooks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dd0559fec08325bccd75b4d1f2e5dc