### PR TITLE
fix(3d): restore stable load order for 3D renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,11 +87,13 @@
   window.createShortNeedleExhaust = createShortNeedleExhaust;
   window.createWarpExhaustBlue = createWarpExhaustBlue;
   window.GLTFLoader = GLTFLoader;
-  THREE.CopyShader = CopyShader;
+  // Nie modyfikujemy namespace'u modułu THREE (jest niemodyfikowalny).
+  // Jeśli coś potrzebuje CopyShader globalnie, wystawiamy go przez window:
+  window.CopyShader = CopyShader;
 
 </script>
-<!-- przełącznik: aktywuj assetowy renderer planet -->
-<script type="module" src="planet3d.assets.js"></script>
+<!-- przełącznik: aktywuj assetowy renderer planet (klasyczny skrypt, aby globalne API było gotowe zanim ruszy pętla gry) -->
+<script src="planet3d.assets.js"></script>
 
 <script>
 // =============== Canvas & utils ===============
@@ -3740,7 +3742,7 @@ function render(alpha, frameDt){
 
   // Czyścimy ekran
   ctx.clearRect(0,0,W,H);
-  updatePlanets3D(frameDt);
+  if (window.updatePlanets3D) updatePlanets3D(frameDt);
 
   // Gwiazdy (proceduralne kafelki na całej mapie)
   drawStars(cam);
@@ -3756,7 +3758,7 @@ function render(alpha, frameDt){
     ctx.beginPath(); ctx.arc(s.x, s.y, w.r * camera.zoom, 0, Math.PI*2); ctx.stroke();
   }
 
-  drawPlanets3D(ctx, cam);
+  if (window.drawPlanets3D)   drawPlanets3D(ctx, cam);
 
   // drogi między stacjami
   const drawn = new Set();

--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -48,7 +48,7 @@
       this.canvas.width = 256; this.canvas.height = 256;
       this.ctx2d = this.canvas.getContext("2d");
       // Zapisz nazwę i odłóż tworzenie sceny do chwili, gdy THREE będzie gotowe.
-      this._name = (opts.name || opts.id || "").toLowerCase();
+      this._name = String((opts && (opts.name ?? opts.id)) ?? "").toLowerCase();
       this._needsInit = true;
       this.spin = 0.04 + Math.random() * 0.06;
     }


### PR DESCRIPTION
## Summary
- expose CopyShader via window instead of mutating the immutable THREE namespace
- load planet3d.assets.js as a classic script so its globals are available when the main loop starts
- guard 3D update/draw calls and cast planet names to strings to avoid runtime crashes

## Testing
- npm ci
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68dd23a3d504832584473b45b1395e61