### PR TITLE
Increase solar system body scales

### DIFF
--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -45,6 +45,10 @@
   let sun = null;
   let asteroidBelt = null;
   const TAU = Math.PI * 2;
+  const PLANET_SIZE_MULTIPLIER = 4.5;
+  const SUN_SIZE_MULTIPLIER = 6.0;
+  const ASTEROID_SCALE_MIN = 0.01;
+  const ASTEROID_SCALE_MAX = 0.035;
 
   // ======= PLANETA Z TEKSTUR =======
   class AssetPlanet3D {
@@ -250,7 +254,7 @@
               const z = (Math.random() - 0.5) * 0.12; // grubość pasa w jednostkach sceny
               const x = Math.cos(a) * r;
               const y = Math.sin(a) * r;
-              const s = 0.018 + Math.random() * 0.045;
+              const s = ASTEROID_SCALE_MIN + Math.random() * (ASTEROID_SCALE_MAX - ASTEROID_SCALE_MIN);
               m.makeTranslation(x, y, z);
               euler.set(Math.random() * TAU, Math.random() * TAU, Math.random() * TAU);
               rotM.makeRotationFromEuler(euler);
@@ -295,13 +299,13 @@
   window.initPlanets3D = function initPlanets3D(list, sunObj) {
     _planets.length = 0;
     for (const s of list) {
-      const size = (s.r || 30) * 2.0;
+      const size = (s.r || 30) * PLANET_SIZE_MULTIPLIER;
       const planet = new AssetPlanet3D(s.x, s.y, size, { name: s.name || s.id || null, type: s.type });
       _planets.push(planet);
     }
 
     if (sunObj) {
-      sun = new Sun3D((sunObj.r || 200) * 2.5);
+      sun = new Sun3D((sunObj.r || 200) * SUN_SIZE_MULTIPLIER);
       sun.x = sunObj.x; sun.y = sunObj.y;
     }
 

--- a/planet3d.js
+++ b/planet3d.js
@@ -5,6 +5,10 @@
   let sun = null;
   let asteroidBelt = null;
   const TAU = Math.PI * 2;
+  const PLANET_SIZE_MULTIPLIER = 4.5;
+  const SUN_SIZE_MULTIPLIER = 6.0;
+  const ASTEROID_SCALE_MIN = 0.01;
+  const ASTEROID_SCALE_MAX = 0.035;
   const clamp = (v, a = 0, b = 1) => Math.max(a, Math.min(b, v));
 
   // PRNG + value noise
@@ -500,7 +504,7 @@
           const x = Math.cos(angle) * radius;
           const y = Math.sin(angle) * radius;
           const z = (Math.random() - 0.5) * 0.22;
-          const s = 0.018 + Math.random() * 0.045;
+          const s = ASTEROID_SCALE_MIN + Math.random() * (ASTEROID_SCALE_MAX - ASTEROID_SCALE_MIN);
 
           m.makeTranslation(x, y, z);
           euler.set(Math.random() * TAU, Math.random() * TAU, Math.random() * TAU);
@@ -658,11 +662,11 @@
   function initPlanets3D(planetList, sunPos) {
     planets.length = 0;
     for (const pl of planetList) {
-      const p = new Planet3D(pl.r * 2.0, pl.type); // mniejsze niż wcześniej, ale wyraźne "halo"
+      const p = new Planet3D(pl.r * PLANET_SIZE_MULTIPLIER, pl.type);
       p.body = pl;
       planets.push(p);
     }
-    sun = new Sun3D(sunPos.r * 2.5);
+    sun = new Sun3D(sunPos.r * SUN_SIZE_MULTIPLIER);
     sun.x = sunPos.x;
     sun.y = sunPos.y;
     asteroidBelt = null;

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -334,6 +334,10 @@ const PLANET_FRAG = `// Terrain generation parameters
   let sun = null;
   let asteroidBelt = null;
   const TAU = Math.PI * 2;
+  const PLANET_SIZE_MULTIPLIER = 4.5;
+  const SUN_SIZE_MULTIPLIER = 6.0;
+  const ASTEROID_SCALE_MIN = 0.01;
+  const ASTEROID_SCALE_MAX = 0.035;
   // Default sun position in sector/world space (center)
   let SUN_POS = { x: 0, y: 0, z: 0 };
 
@@ -786,7 +790,7 @@ const PLANET_FRAG = `// Terrain generation parameters
           const x = Math.cos(angle) * radius;
           const y = Math.sin(angle) * radius;
           const z = (Math.random() - 0.5) * 0.22;
-          const s = 0.018 + Math.random() * 0.045;
+          const s = ASTEROID_SCALE_MIN + Math.random() * (ASTEROID_SCALE_MAX - ASTEROID_SCALE_MIN);
 
           m.makeTranslation(x, y, z);
           euler.set(Math.random() * TAU, Math.random() * TAU, Math.random() * TAU);
@@ -955,13 +959,13 @@ const PLANET_FRAG = `// Terrain generation parameters
   function initPlanets3D(list, sunObj) {
     _planets.length = 0;
     for (const s of list) {
-      const size = (s.r || 30) * 2.0;
+      const size = (s.r || 30) * PLANET_SIZE_MULTIPLIER;
       const p = new ProcPlanet(s.x, s.y, size, { style: s.type || null });
       _planets.push(p);
     }
     if (sunObj) {
       SUN_POS = { x: sunObj.x || 0, y: sunObj.y || 0, z: 0 };
-      sun = new Sun3D((sunObj.r || 200) * 2.5);
+      sun = new Sun3D((sunObj.r || 200) * SUN_SIZE_MULTIPLIER);
       sun.x = sunObj.x;
       sun.y = sunObj.y;
     }


### PR DESCRIPTION
## Summary
- significantly increase the rendered pixel scale for planets and the sun in all 3D renderer variants
- reduce the instanced asteroid mesh scale to make the belt rocks noticeably smaller
- centralize the size multipliers into reusable constants across the renderers

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68dd86e714608325808acaeaa2a105cc