### PR TITLE
Adjust pirate station 3D scale

### DIFF
--- a/src/3d/world3d.js
+++ b/src/3d/world3d.js
@@ -153,7 +153,7 @@ export function attachPirateStation3D(sceneOverride, station2D) {
   }
   ensureScene();
   ensureCamera();
-  pirateStation3D = createPirateStation({ scale: 1.0 });
+  pirateStation3D = createPirateStation({ worldRadius: 120 });
   pirateStation2D = station2D || null;
   pirateStation3D.object3d.position.set(station2D?.x || 0, 0, station2D?.y || 0);
   scene.add(pirateStation3D.object3d);

--- a/src/space/pirateStation/pirateStationFactory.js
+++ b/src/space/pirateStation/pirateStationFactory.js
@@ -428,8 +428,11 @@ function buildPirateStation(THREE, opts = {}) {
 }
 
 export function createPirateStation(opts = {}) {
+  const baseRadius = 48; // geometry radius when scale === 1
+  const requestedRadius = typeof opts.worldRadius === 'number' ? opts.worldRadius : null;
+  const scale = requestedRadius ? requestedRadius / baseRadius : opts.scale ?? 1;
   const { group, update, radius } = buildPirateStation(THREE, {
-    scale: opts.scale ?? 1,
+    scale,
     name: opts.name || 'PirateStation'
   });
   return {


### PR DESCRIPTION
## Summary
- allow createPirateStation to derive scale from a requested world radius
- align the 3D pirate station overlay with the 2D station size by requesting a 120 unit radius

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68dd9b0f586083258278b30cc3f157ef