### PR TITLE
Add railgun explosion overlay VFX

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
 <style>
   html,body{height:100%;margin:0;background:#030417;color:#dfe7ff;font-family:Inter,system-ui,Segoe UI,Roboto,Arial}
   #ui{position:absolute;left:12px;top:12px;z-index:20;background:rgba(8,10,20,0.6);padding:10px;border-radius:8px;backdrop-filter:blur(6px)}
-    canvas{display:block;width:100vw;height:100vh}
+  canvas{display:block;width:100vw;height:100vh}
+  #game-root{position:relative;width:100vw;height:100vh;}
+  #game-root>canvas{display:block;width:100%;height:100%;}
   #c { position: relative; z-index: 10; }
   canvas:not(#c) { pointer-events: none !important; position: absolute; inset: 0; z-index: 0; }
   .stat{font-family:monospace;font-size:13px}
@@ -45,7 +47,9 @@
     <div class="stat">LPM — rail (A→B, A→B) · PPM — boczne rakiety · F — superbroń · SHIFT — warp · SPACJA — dopalacz</div>
     <div style="margin-top:6px"><small>Gwiazdy są proceduralne w całej galaktyce. Silnik: niebieski exhaust + krótki ślad przy ruchu.</small></div>
   </div>
-<canvas id="c"></canvas>
+<div id="game-root">
+  <canvas id="c"></canvas>
+</div>
 <div id="loading">Ładowanie...</div>
 <div id="mechanic-overlay" class="station-overlay hidden">
   <h3>Station Mechanic</h3>
@@ -79,6 +83,8 @@
   import { createShortNeedleExhaust, createWarpExhaustBlue } from "./Engineeffects.js";
   import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
   import { initWorld3D, attachPirateStation3D, dettachPirateStation3D, updateWorld3D, drawWorld3D } from "./src/3d/world3d.js";
+  import { initOverlay } from "./src/effects3d/overlay.js";
+  import { createRailgunExplosionFactory } from "./src/effects3d/railgunExplosion.js";
   window.THREE = THREE;
   window.EffectComposer  = EffectComposer;
   window.RenderPass      = RenderPass;
@@ -93,6 +99,8 @@
   window.dettachPirateStation3D = dettachPirateStation3D;
   window.updateWorld3D = updateWorld3D;
   window.drawWorld3D = drawWorld3D;
+  window.initOverlay3D = initOverlay;
+  window.createRailgunExplosionFactory = createRailgunExplosionFactory;
   // Nie modyfikujemy namespace'u modułu THREE (jest niemodyfikowalny).
   // Jeśli coś potrzebuje CopyShader globalnie, wystawiamy go przez window:
   window.CopyShader = CopyShader;
@@ -104,9 +112,33 @@
 <script>
 // =============== Canvas & utils ===============
 const canvas = document.getElementById('c');
+const gameRoot = document.getElementById('game-root');
 const ctx = canvas.getContext('2d');
 let W = canvas.width = innerWidth, H = canvas.height = innerHeight;
-window.addEventListener('resize', ()=>{ W = canvas.width = innerWidth; H = canvas.height = innerHeight; initStars(true); });
+
+const overlayView = {
+  center: { x: 0, y: 0 },
+  viewport: { w: W, h: H },
+  zoom: 1,
+};
+
+let overlay3D = null;
+let railgunExplosionFactory = null;
+
+function triggerRailgunExplosion3D(x, y) {
+  if (!overlay3D || !railgunExplosionFactory) return;
+  const effect = railgunExplosionFactory({ x, y });
+  overlay3D.spawn(effect);
+}
+
+window.addEventListener('resize', ()=>{
+  W = canvas.width = innerWidth;
+  H = canvas.height = innerHeight;
+  overlayView.viewport.w = W;
+  overlayView.viewport.h = H;
+  if (overlay3D) overlay3D.resize();
+  initStars(true);
+});
 
 let mainScene3D = null;
 
@@ -525,6 +557,20 @@ const camera = {
   addShake(mag, dur){ this.shakeMag = mag; this.shakeTime = dur; this.shakeDur = dur; }
 };
 
+overlayView.zoom = camera.zoom;
+if (window.initOverlay3D && window.createRailgunExplosionFactory && gameRoot) {
+  overlay3D = window.initOverlay3D({
+    host: gameRoot,
+    getView() {
+      return overlayView;
+    }
+  });
+  if (overlay3D) {
+    railgunExplosionFactory = window.createRailgunExplosionFactory(overlay3D.scene);
+    overlay3D.resize();
+  }
+}
+
 // =============== Ship ===============
 const ship = {
   w:100, h:300, mass:140,
@@ -552,6 +598,8 @@ const SHIP_VISUAL_BASE = {
   turretBottom: { x: 42.60145666564039, y:  43.668730035791256 },
   engineY: 119.44796580188681
 };
+overlayView.center.x = ship.pos.x;
+overlayView.center.y = ship.pos.y;
 (function configureShip(){
   const hw = ship.w/2, hh = ship.h/2;
   ship.visual = {
@@ -1162,6 +1210,7 @@ function spawnRailHitEffect(x,y,scale=1){
     spawnParticle({x,y}, {x:Math.cos(a)*s, y:Math.sin(a)*s}, 0.25 + Math.random()*0.35, '#bfe7ff', 1 + Math.random()*2, true);
   }
   spawnParticle({x,y}, {x:0,y:0}, 0.12, '#ffffff', 6 * scale, true);
+  triggerRailgunExplosion3D(x, y);
 }
 function spawnDefaultHit(x,y,scale=1){
   for(let i=0;i<14*scale;i++){
@@ -3455,6 +3504,9 @@ function loop(now){
     if(camera.shakeTime <= 0) camera.shakeMag = 0;
   }
   render(alpha, frame);
+  if (overlay3D) {
+    overlay3D.tick(frame);
+  }
   requestAnimationFrame(loop);
 }
 
@@ -3926,6 +3978,12 @@ function render(alpha, frameDt){
     cam.x += (Math.random()*2 - 1) * mag;
     cam.y += (Math.random()*2 - 1) * mag;
   }
+
+  overlayView.center.x = cam.x;
+  overlayView.center.y = cam.y;
+  overlayView.viewport.w = W;
+  overlayView.viewport.h = H;
+  overlayView.zoom = cam.zoom;
 
   // aktualizuj wyświetlanie czasu
   gameTimeEl.textContent = formatGameTime(gameTime);

--- a/src/effects3d/overlay.js
+++ b/src/effects3d/overlay.js
@@ -1,0 +1,108 @@
+import * as THREE from "three";
+
+export function initOverlay({ host, getView }) {
+  if (!host) {
+    throw new Error("initOverlay: host element is required");
+  }
+
+  const canvas = document.createElement("canvas");
+  Object.assign(canvas.style, {
+    position: "absolute",
+    inset: "0",
+    pointerEvents: "none",
+    zIndex: 5,
+  });
+  host.appendChild(canvas);
+
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+  renderer.autoClear = true;
+  renderer.setClearColor(0x000000, 0);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.05;
+  renderer.setSize(host.clientWidth, host.clientHeight, false);
+
+  const scene = new THREE.Scene();
+
+  const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, -1000, 1000);
+  camera.up.set(0, 0, -1);
+  camera.position.set(0, 120, 0);
+  camera.lookAt(0, 0, 0);
+
+  const effects = [];
+  let lastSizeW = host.clientWidth;
+  let lastSizeH = host.clientHeight;
+
+  function syncCamera() {
+    if (!getView) return;
+    const view = getView();
+    if (!view) return;
+
+    const viewport = view.viewport || {};
+    const w = viewport.w ?? host.clientWidth;
+    const h = viewport.h ?? host.clientHeight;
+    const zoom = view.zoom ?? 1;
+    const scale = zoom || 1;
+    const halfW = w / (2 * scale);
+    const halfH = h / (2 * scale);
+
+    if (camera.left !== -halfW || camera.right !== halfW || camera.top !== halfH || camera.bottom !== -halfH) {
+      camera.left = -halfW;
+      camera.right = halfW;
+      camera.top = halfH;
+      camera.bottom = -halfH;
+      camera.updateProjectionMatrix();
+    }
+
+    const center = view.center || {};
+    const cx = center.x ?? 0;
+    const cz = center.y ?? 0;
+
+    if (camera.position.x !== cx || camera.position.z !== cz) {
+      camera.position.set(cx, camera.position.y, cz);
+      camera.lookAt(cx, 0, cz);
+    }
+
+    if (lastSizeW !== w || lastSizeH !== h) {
+      renderer.setSize(w, h, false);
+      lastSizeW = w;
+      lastSizeH = h;
+    }
+  }
+
+  function tick(dt) {
+    syncCamera();
+
+    for (let i = effects.length - 1; i >= 0; i--) {
+      const fx = effects[i];
+      if (fx.update) {
+        fx.update(dt);
+      }
+      if (!fx.group || !fx.group.parent) {
+        effects.splice(i, 1);
+      }
+    }
+
+    renderer.render(scene, camera);
+  }
+
+  function spawn(effect) {
+    if (!effect) return;
+    effects.push(effect);
+  }
+
+  function resize() {
+    syncCamera();
+  }
+
+  function dispose() {
+    effects.length = 0;
+    if (canvas.parentElement === host) {
+      host.removeChild(canvas);
+    }
+    renderer.dispose();
+  }
+
+  return { scene, camera, renderer, tick, spawn, resize, dispose };
+}

--- a/src/effects3d/railgunExplosion.js
+++ b/src/effects3d/railgunExplosion.js
@@ -1,0 +1,239 @@
+import * as THREE from "three";
+
+const sharedTextures = {
+  flash: null,
+  smoke: null,
+};
+
+function ensureTextures() {
+  if (!sharedTextures.flash) {
+    sharedTextures.flash = makeRadialTexture(512);
+  }
+  if (!sharedTextures.smoke) {
+    sharedTextures.smoke = makeSmokeTexture(256);
+  }
+}
+
+export function createRailgunExplosionFactory(scene) {
+  ensureTextures();
+
+  return function spawn({ x = 0, y = 0, z } = {}) {
+    const group = new THREE.Group();
+    group.position.set(x, 0, z !== undefined ? z : y);
+    scene.add(group);
+
+    const flashMaterial = new THREE.SpriteMaterial({
+      map: sharedTextures.flash,
+      blending: THREE.AdditiveBlending,
+      transparent: true,
+      depthWrite: false,
+      depthTest: false,
+      opacity: 0.85,
+      color: 0xffffff,
+    });
+    const flash = new THREE.Sprite(flashMaterial);
+    flash.scale.setScalar(3);
+    flash.position.y = 0.25;
+    group.add(flash);
+
+    const coreMaterial = new THREE.SpriteMaterial({
+      map: sharedTextures.flash,
+      blending: THREE.AdditiveBlending,
+      transparent: true,
+      depthWrite: false,
+      depthTest: false,
+      opacity: 0.95,
+      color: 0x99e6ff,
+    });
+    const core = new THREE.Sprite(coreMaterial);
+    core.scale.setScalar(1.6);
+    core.position.y = 0.7;
+    group.add(core);
+
+    const sparkCount = 54;
+    const sparkGeometry = new THREE.PlaneGeometry(1, 0.14);
+    const sparkMaterial = new THREE.MeshBasicMaterial({
+      color: 0xb0f2ff,
+      transparent: true,
+      opacity: 1,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    const sparks = new THREE.InstancedMesh(sparkGeometry, sparkMaterial, sparkCount);
+    sparks.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+    sparks.frustumCulled = false;
+    group.add(sparks);
+
+    const sparkTransform = new THREE.Object3D();
+    const sparkData = new Array(sparkCount).fill(null).map(() => {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 70 + Math.random() * 140;
+      const life = 0.14 + Math.random() * 0.22;
+      const length = 2.6 + Math.random() * 6.0;
+      const thickness = 0.18 + Math.random() * 0.18;
+      const elevation = 0.15 + Math.random() * 0.4;
+      return {
+        angle,
+        speed,
+        life,
+        age: 0,
+        length,
+        thickness,
+        elevation,
+      };
+    });
+
+    sparkData.forEach((data, i) => {
+      sparkTransform.position.set(0, data.elevation, 0);
+      sparkTransform.rotation.set(-Math.PI / 2, 0, -data.angle);
+      sparkTransform.scale.set(data.length, data.thickness, 1);
+      sparkTransform.updateMatrix();
+      sparks.setMatrixAt(i, sparkTransform.matrix);
+    });
+    sparks.instanceMatrix.needsUpdate = true;
+
+    const baseSmokeMaterial = new THREE.SpriteMaterial({
+      map: sharedTextures.smoke,
+      color: 0xdde6ff,
+      transparent: true,
+      depthWrite: false,
+      opacity: 0.22,
+    });
+
+    const smokes = [];
+    for (let i = 0; i < 10; i++) {
+      const mat = baseSmokeMaterial.clone();
+      const smoke = new THREE.Sprite(mat);
+      smoke.position.set((Math.random() - 0.5) * 0.8, 0.1, (Math.random() - 0.5) * 0.8);
+      const scale = 1.1 + Math.random() * 1.5;
+      smoke.scale.setScalar(scale);
+      smoke.userData = {
+        vx: (Math.random() - 0.5) * 8,
+        vz: (Math.random() - 0.5) * 8,
+        growth: 1.3 + Math.random() * 0.6,
+        age: 0,
+        life: 0.7 + Math.random() * 0.5,
+      };
+      smokes.push(smoke);
+      group.add(smoke);
+    }
+
+    const light = new THREE.PointLight(0x9ad9ff, 120, 110, 2);
+    light.position.set(0, 6, 0);
+    group.add(light);
+
+    const duration = 0.6;
+    let time = 0;
+    let disposed = false;
+
+    function update(dt) {
+      if (disposed) return;
+      time += dt;
+
+      const flashFade = Math.max(0, 1 - time / 0.09);
+      flashMaterial.opacity = 0.85 * flashFade;
+      const flashScale = 3 + time * 26;
+      flash.scale.setScalar(flashScale);
+
+      const coreFade = Math.max(0, 1 - time / 0.16);
+      coreMaterial.opacity = 0.95 * coreFade;
+      const coreScale = 1.6 + Math.max(0, 0.6 - time * 2.5);
+      core.scale.setScalar(coreScale);
+
+      for (let i = 0; i < sparkData.length; i++) {
+        const data = sparkData[i];
+        data.age += dt;
+        const ageNorm = Math.max(0, 1 - data.age / data.life);
+        const dist = data.speed * data.age * 0.02;
+        const px = Math.cos(data.angle) * dist;
+        const pz = Math.sin(data.angle) * dist;
+
+        sparkTransform.position.set(px, 0.12, pz);
+        sparkTransform.rotation.set(-Math.PI / 2, 0, -data.angle);
+        sparkTransform.scale.set(
+          data.length * (0.5 + 0.5 * ageNorm),
+          data.thickness * (0.7 + 0.3 * ageNorm),
+          1,
+        );
+        sparkTransform.updateMatrix();
+        sparks.setMatrixAt(i, sparkTransform.matrix);
+      }
+      sparks.instanceMatrix.needsUpdate = true;
+      sparkMaterial.opacity = 0.9 * Math.max(0, 1 - time / 0.22);
+
+      for (let i = smokes.length - 1; i >= 0; i--) {
+        const smoke = smokes[i];
+        const state = smoke.userData;
+        state.age += dt;
+        smoke.position.x += state.vx * dt;
+        smoke.position.z += state.vz * dt;
+        smoke.scale.multiplyScalar(1 + state.growth * dt);
+        const lifeT = Math.min(1, state.age / state.life);
+        smoke.material.opacity = 0.22 * (1 - lifeT) * Math.max(0, 1 - time / 0.55);
+        if (state.age >= state.life) {
+          group.remove(smoke);
+          smoke.material.dispose();
+          smokes.splice(i, 1);
+        }
+      }
+
+      light.intensity = 140 * Math.max(0, 1 - time / 0.12);
+
+      if (time > duration + 0.6) {
+        dispose();
+      }
+    }
+
+    function dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (group.parent) {
+        group.parent.remove(group);
+      }
+      flashMaterial.dispose();
+      coreMaterial.dispose();
+      sparks.dispose();
+      sparkGeometry.dispose();
+      sparkMaterial.dispose();
+      smokes.forEach((smoke) => {
+        smoke.material.dispose();
+      });
+      baseSmokeMaterial.dispose();
+    }
+
+    return { update, dispose, group };
+  };
+}
+
+function makeRadialTexture(size = 256, inner = "#eaffff", mid = "rgba(120,220,255,0.9)", outer = "rgba(0,180,255,0)") {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  gradient.addColorStop(0, inner);
+  gradient.addColorStop(0.32, mid);
+  gradient.addColorStop(1, outer);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  return texture;
+}
+
+function makeSmokeTexture(size = 256) {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  ctx.clearRect(0, 0, size, size);
+  const gradient = ctx.createRadialGradient(size / 2, size / 2, size * 0.05, size / 2, size / 2, size * 0.48);
+  gradient.addColorStop(0, "rgba(255,255,255,0.55)");
+  gradient.addColorStop(1, "rgba(255,255,255,0)");
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(size / 2, size / 2, size * 0.48, 0, Math.PI * 2);
+  ctx.fill();
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  return texture;
+}


### PR DESCRIPTION
## Summary
- add a lightweight Three.js overlay renderer to host 3D effects above the 2D canvas
- implement a railgun explosion effect with flash, sparks, smoke, and short-lived light
- integrate the overlay with the main loop and trigger the effect on rail hits

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dee444d9748325837db2780cd977b4