### PR TITLE
Raise overlay canvas z-index above gameplay canvas

### DIFF
--- a/src/effects3d/overlay.js
+++ b/src/effects3d/overlay.js
@@ -10,7 +10,7 @@ export function initOverlay({ host, getView }) {
     position: "absolute",
     inset: "0",
     pointerEvents: "none",
-    zIndex: 5,
+    zIndex: 15,
   });
   host.appendChild(canvas);
 


### PR DESCRIPTION
## Summary
- increase the overlay renderer canvas z-index so 3D effects draw above the main gameplay canvas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68df87a30a84832589ca13d59ce21cc7