### PR TITLE
feat: add PirateStation3D overlay and tooling controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ let mainScene3D = null;
 window.DevFlags = Object.assign({
   showRuler: false,
   unlimitedWarp: false,
-  use3DPirateStation: false
+  use3DPirateStation: true
 }, window.DevFlags || {});
 
 window.DevTuning = Object.assign({
@@ -137,6 +137,8 @@ window.DevTuning = Object.assign({
 
 const DevFlags = window.DevFlags;
 const DevTuning = window.DevTuning;
+const Dev = window.Dev = window.Dev || {};
+if (typeof Dev.station3DScale !== 'number') Dev.station3DScale = 1.0;
 
 const clamp = (v,a,b)=>Math.max(a,Math.min(b,v));
 const add = (a,b)=>({x:a.x+b.x,y:a.y+b.y});
@@ -883,6 +885,15 @@ let stations = planets.map(pl => {
 
 for (const st of stations) {
   if (st.baseR == null) st.baseR = st.r;
+}
+
+if (window.initStations3D) initStations3D(stations);
+window.USE_STATION_3D = true;
+if (window.__setStation3DScale) {
+  window.__lastStationScale = 1;
+  if (window.Dev && typeof Dev.station3DScale === 'number') {
+    __setStation3DScale(Dev.station3DScale);
+  }
 }
 
 // oznacz stacje wewnątrz pasa asteroid
@@ -3995,6 +4006,7 @@ function render(alpha, frameDt){
   // Czyścimy ekran
   ctx.clearRect(0,0,W,H);
   if (window.updatePlanets3D) updatePlanets3D(frameDt);
+  if (window.USE_STATION_3D && window.updateStations3D) updateStations3D(frameDt);
   if (window.updateWorld3D) updateWorld3D(frameDt, vfxTime);
 
   // Gwiazdy (proceduralne kafelki na całej mapie)
@@ -4012,6 +4024,7 @@ function render(alpha, frameDt){
   }
 
   if (window.drawPlanets3D)   drawPlanets3D(ctx, cam);
+  if (window.USE_STATION_3D && window.drawStations3D) drawStations3D(ctx, cam);
   if (window.drawWorld3D)     drawWorld3D(ctx, cam, worldToScreen);
   drawPlanetLabels(ctx, cam);
   // Miarka dystansu (jeśli włączona)
@@ -4046,31 +4059,26 @@ function render(alpha, frameDt){
     ctx.stroke();
   }
 
-  // Stacje
-  for(const st of stations){
-    const s = worldToScreen(st.x, st.y, cam);
-    const pirate = st.isPirate || st.type === 'pirate' || st.style === 'pirate' || (st.name && st.name.toLowerCase().includes('pir'));
-    const use3D = !!(window.DevFlags && DevFlags.use3DPirateStation);
-    const ready3D = typeof window.isPirate3DReady === 'function' ? window.isPirate3DReady() : false;
-    const skip2D = use3D && ready3D && pirate;
-    const scale = pirate ? DevTuning.pirateStationScale : 1.0;
-    const visR = (st.baseR || st.r) * scale;
-    const rr = visR * camera.zoom;
+  if (!window.USE_STATION_3D) {
+    for (const st of stations){
+      const s = worldToScreen(st.x, st.y, cam);
+      const pirate = st.isPirate || st.type === 'pirate' || st.style === 'pirate' || (st.name && st.name.toLowerCase().includes('pir'));
+      const scale = pirate ? DevTuning.pirateStationScale : 1.0;
+      const visR = (st.baseR || st.r) * scale;
+      const rr = visR * camera.zoom;
 
-    if (skip2D) {
-      // Pomijamy rysowanie 2D – model 3D dokleja się w drawPlanets3D(...)
-    } else {
       drawStationShadow(ctx, st, cam);
       drawStationVFX(ctx, st, s.x, s.y, rr, gameTime);
+
+      for (let i=0;i<st.ports.length;i++){
+        const pw = stationPortWorld(st, i);
+        const ps = worldToScreen(pw.x, pw.y, cam);
+        ctx.fillStyle = '#60a5fa';
+        ctx.beginPath(); ctx.arc(ps.x, ps.y, 4*camera.zoom, 0, Math.PI*2); ctx.fill();
+      }
+      ctx.fillStyle = '#dfe7ff'; ctx.font = `${12*camera.zoom}px monospace`;
+      ctx.fillText('ST'+st.id, s.x - rr*0.35, s.y + 4*camera.zoom);
     }
-    for(let i=0;i<st.ports.length;i++){
-      const pw = stationPortWorld(st, i);
-      const ps = worldToScreen(pw.x, pw.y, cam);
-      ctx.fillStyle = '#60a5fa';
-      ctx.beginPath(); ctx.arc(ps.x, ps.y, 4*camera.zoom, 0, Math.PI*2); ctx.fill();
-    }
-    ctx.fillStyle = '#dfe7ff'; ctx.font = `${12*camera.zoom}px monospace`;
-    ctx.fillText('ST'+st.id, s.x - rr*0.35, s.y + 4*camera.zoom);
   }
 
   // Laser beams
@@ -4883,6 +4891,8 @@ setTimeout(startGame, 500);
   const elRuler     = document.getElementById('dt-show-ruler');
   const elScale     = document.getElementById('dt-pirate-scale');
   const elScaleVal  = document.getElementById('dt-pirate-scale-value');
+  const elStation3DScale = document.getElementById('dt-station3d-scale');
+  const elStation3DScaleVal = document.getElementById('dt-station3d-scale-value');
   const elPir3D     = document.getElementById('dt-use-3d-pirate');
 
   if (elUnlimited) {
@@ -4917,6 +4927,23 @@ setTimeout(startGame, 500);
     if (elScaleVal) elScaleVal.textContent = DevTuning.pirateStationScale.toFixed(2);
   };
 
+  const applyStation3DScale = () => {
+    if (!elStation3DScale) return;
+    const v = parseFloat(elStation3DScale.value);
+    Dev.station3DScale = isFinite(v) ? v : 1.0;
+    if (window.DevConfig) {
+      window.DevConfig.station3DScale = Dev.station3DScale;
+    }
+    if (window.__setStation3DScale && window.USE_STATION_3D) {
+      __setStation3DScale(Dev.station3DScale);
+    }
+    if (elStation3DScaleVal) elStation3DScaleVal.textContent = Dev.station3DScale.toFixed(2);
+    const legacy = document.getElementById('station3DScale');
+    const legacyVal = document.getElementById('station3DScaleVal');
+    if (legacy) legacy.value = String(Dev.station3DScale);
+    if (legacyVal) legacyVal.textContent = '×' + Dev.station3DScale.toFixed(2);
+  };
+
   if (elScale) {
     if (!isFinite(parseFloat(elScale.value))) {
       elScale.value = String(DevTuning.pirateStationScale);
@@ -4928,11 +4955,29 @@ setTimeout(startGame, 500);
     elScaleVal.textContent = DevTuning.pirateStationScale.toFixed(2);
   }
 
+  if (elStation3DScale) {
+    if (!isFinite(parseFloat(elStation3DScale.value))) {
+      elStation3DScale.value = String(Dev.station3DScale);
+    }
+    elStation3DScale.addEventListener('input', applyStation3DScale);
+    elStation3DScale.addEventListener('change', applyStation3DScale);
+    applyStation3DScale();
+  } else if (elStation3DScaleVal) {
+    elStation3DScaleVal.textContent = Dev.station3DScale.toFixed(2);
+  }
+
   if (elPir3D){
-    elPir3D.checked = !!(window.DevFlags && DevFlags.use3DPirateStation);
+    if (typeof DevFlags.use3DPirateStation === 'boolean') {
+      window.USE_STATION_3D = DevFlags.use3DPirateStation;
+    }
+    elPir3D.checked = window.USE_STATION_3D !== false;
     elPir3D.addEventListener('change', e=>{
       if (!window.DevFlags) window.DevFlags = {};
       DevFlags.use3DPirateStation = e.target.checked;
+      window.USE_STATION_3D = e.target.checked;
+      if (window.USE_STATION_3D && window.__setStation3DScale && typeof Dev.station3DScale === 'number') {
+        __setStation3DScale(Dev.station3DScale);
+      }
     });
   }
 })();
@@ -4984,6 +5029,11 @@ setTimeout(startGame, 500);
       <input id="pirScale" type="range" min="0.4" max="5" step="0.01">
       <div class="val" id="pirScaleVal"></div>
     </div>
+    <div class="row">
+      <label>Skala stacji 3D (×)</label>
+      <input id="station3DScale" type="range" min="0.2" max="3.0" step="0.05" value="1.0">
+      <div class="val" id="station3DScaleVal"></div>
+    </div>
     <label style="display:flex;gap:6px;align-items:center;margin-top:8px">
       <input id="dt-use-3d-pirate" type="checkbox" />
       3D Pirate Station (hide 2D)
@@ -5024,6 +5074,7 @@ setTimeout(startGame, 500);
     planetRById: {},            // { [id or name]: R }
     planetScaleAll: 1,          // mnożnik globalny ×R
     pirateScale: 1.0,           // mnożnik rysowania stacji pirackiej
+    station3DScale: 1.0,        // mnożnik nakładki 3D
   };
   const DevFlags = window.DevFlags;
   window.DevConfig = DevConfig;
@@ -5035,6 +5086,7 @@ setTimeout(startGame, 500);
     sunR: el('sunR'), sunRVal: el('sunRVal'),
     planetScaleAll: el('planetScaleAll'), planetScaleAllVal: el('planetScaleAllVal'),
     pirScale: el('pirScale'), pirScaleVal: el('pirScaleVal'),
+    station3DScale: el('station3DScale'), station3DScaleVal: el('station3DScaleVal'),
     planetsGroup: el('planetsGroup'),
     cbRuler: el('toggleRuler'),
     cbUnlimited: el('toggleUnlimitedWarp'),
@@ -5063,6 +5115,9 @@ setTimeout(startGame, 500);
         if (typeof DevConfig.pirateScale === 'number') {
           DevTuning.pirateStationScale = DevConfig.pirateScale;
         }
+        if (typeof DevConfig.station3DScale === 'number') {
+          Dev.station3DScale = DevConfig.station3DScale;
+        }
       }
       if (flags && typeof flags==='object'){
         Object.assign(DevFlags, flags);
@@ -5070,6 +5125,13 @@ setTimeout(startGame, 500);
     } catch {}
     if (typeof DevConfig.pirateScale !== 'number') {
       DevConfig.pirateScale = DevTuning.pirateStationScale;
+    }
+    if (typeof DevConfig.station3DScale !== 'number') {
+      DevConfig.station3DScale = Dev.station3DScale;
+    }
+    if (window.__setStation3DScale && window.USE_STATION_3D) {
+      window.__lastStationScale = 1;
+      __setStation3DScale(Dev.station3DScale);
     }
   }
   function saveLS(){
@@ -5151,9 +5213,14 @@ setTimeout(startGame, 500);
 
   function reflectToUI(){
     DevConfig.pirateScale = DevTuning.pirateStationScale;
+    DevConfig.station3DScale = Dev.station3DScale;
     ui.sunR.value = DevConfig.sunR|0; ui.sunRVal.textContent = ui.sunR.value;
     ui.planetScaleAll.value = DevConfig.planetScaleAll; ui.planetScaleAllVal.textContent = '×'+(+DevConfig.planetScaleAll).toFixed(2);
     ui.pirScale.value = DevConfig.pirateScale; ui.pirScaleVal.textContent = '×'+(+DevConfig.pirateScale).toFixed(2);
+    if (ui.station3DScale) {
+      ui.station3DScale.value = DevConfig.station3DScale;
+      if (ui.station3DScaleVal) ui.station3DScaleVal.textContent = '×'+(+DevConfig.station3DScale).toFixed(2);
+    }
     ui.cbRuler.checked = DevFlags.showRuler;
     ui.cbUnlimited.checked = DevFlags.unlimitedWarp;
     if (ui.cbPirate3D) ui.cbPirate3D.checked = DevFlags.use3DPirateStation;
@@ -5163,7 +5230,8 @@ setTimeout(startGame, 500);
       sunR: DevConfig.sunR|0,
       planetRById: DevConfig.planetRById,
       planetScaleAll: +DevConfig.planetScaleAll,
-      pirateScale: +DevConfig.pirateScale
+      pirateScale: +DevConfig.pirateScale,
+      station3DScale: +DevConfig.station3DScale
     };
     ui.cfgOut.value = JSON.stringify(out, null, 2);
   }
@@ -5178,11 +5246,30 @@ setTimeout(startGame, 500);
     saveLS();
     reflectToCfg();
   });
+  if (ui.station3DScale) {
+    ui.station3DScale.addEventListener('input', ()=>{
+      Dev.station3DScale = +ui.station3DScale.value;
+      DevConfig.station3DScale = Dev.station3DScale;
+      if (ui.station3DScaleVal) ui.station3DScaleVal.textContent = '×'+(+DevConfig.station3DScale).toFixed(2);
+      if (window.__setStation3DScale && window.USE_STATION_3D) {
+        __setStation3DScale(Dev.station3DScale);
+      }
+      saveLS();
+      reflectToCfg();
+    });
+  }
 
   ui.cbRuler.addEventListener('change', ()=>{ DevFlags.showRuler = ui.cbRuler.checked; saveLS(); });
   ui.cbUnlimited.addEventListener('change', ()=>{ DevFlags.unlimitedWarp = ui.cbUnlimited.checked; saveLS(); });
   if (ui.cbPirate3D) {
-    ui.cbPirate3D.addEventListener('change', ()=>{ DevFlags.use3DPirateStation = ui.cbPirate3D.checked; saveLS(); });
+    ui.cbPirate3D.addEventListener('change', ()=>{
+      DevFlags.use3DPirateStation = ui.cbPirate3D.checked;
+      window.USE_STATION_3D = ui.cbPirate3D.checked;
+      if (window.USE_STATION_3D && window.__setStation3DScale && typeof Dev.station3DScale === 'number') {
+        __setStation3DScale(Dev.station3DScale);
+      }
+      saveLS();
+    });
   }
 
   ui.btnCopy.addEventListener('click', async ()=>{

--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -47,7 +47,6 @@
   const _planets = [];
   let sun = null;
   let asteroidBelt = null;
-  let pirate3D = null;
   const TAU = Math.PI * 2;
   const PLANET_SIZE_MULTIPLIER = 4.5;
   const SUN_SIZE_MULTIPLIER = 6.0;
@@ -341,81 +340,78 @@
     }
   }
 
+  const _stations3D = [];
+
   class PirateStation3D {
-    constructor(stationRef, sunRef){
-      this.ref = stationRef;
-      this.sunRef = sunRef;
+    constructor(worldX, worldY, pixelSize, opts = {}) {
+      this.x = worldX; this.y = worldY;
+      this.size = pixelSize || 900;
+      this.spin = 0.08;
       this.canvas = document.createElement('canvas');
-      this.canvas.width = 512;
-      this.canvas.height = 512;
+      this.canvas.width = 512; this.canvas.height = 512;
       this.ctx2d = this.canvas.getContext('2d');
-      this._ready = false;
-      this.spin = 0.15;
       this._needsInit = true;
     }
 
-    _initIfNeeded(){
+    _lazyInit() {
       if (!this._needsInit || typeof THREE === 'undefined') return;
       this._needsInit = false;
 
       this.scene = new THREE.Scene();
-      this.camera = new THREE.PerspectiveCamera(45, 1, 0.1, 200);
-      this.camera.position.set(0, 0.6, 4.2);
-      this.camera.lookAt(0, 0, 0);
+      this.camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+      this.camera.position.z = 4.2;
 
-      const amb = new THREE.AmbientLight(0x8899aa, 0.5);
-      this.scene.add(amb);
-      const dir = new THREE.DirectionalLight(0xffffff, 1.1);
-      this.scene.add(dir);
-      this._dirLight = dir;
+      this.scene.add(new THREE.AmbientLight(0x334455, 0.6));
+      const key = new THREE.DirectionalLight(0xffffff, 1.1);
+      key.position.set(2.5, 3.5, 5.0);
+      this.scene.add(key);
 
-      const coreMat  = new THREE.MeshStandardMaterial({ color: 0x66ccff, emissive: 0x2277ff, emissiveIntensity: 1.0, roughness: 0.3, metalness: 0.1 });
-      const ringMat  = new THREE.MeshStandardMaterial({ color: 0x2b3a55, metalness: 0.6, roughness: 0.4 });
+      const ringMat    = new THREE.MeshStandardMaterial({ color: 0x7fb2ff, metalness: 0.2, roughness: 0.35, emissive: 0x0a1e3a, emissiveIntensity: 0.7 });
+      const innerMat   = new THREE.MeshStandardMaterial({ color: 0x2a3a5a, metalness: 0.1, roughness: 0.8 });
+      const hubMat     = new THREE.MeshStandardMaterial({ color: 0x9fd3ff, emissive: 0x164b8c, emissiveIntensity: 1.1, metalness: 0.0, roughness: 0.9 });
+      const spokeMat   = new THREE.MeshStandardMaterial({ color: 0x6da8ff, metalness: 0.3, roughness: 0.6 });
 
-      const core = new THREE.Mesh(new THREE.SphereGeometry(0.55, 48, 32), coreMat);
-      this.scene.add(core);
+      const outerRing = new THREE.Mesh(new THREE.TorusGeometry(1.35, 0.07, 20, 128), ringMat);
+      outerRing.rotation.x = Math.PI/2;
+      this.scene.add(outerRing);
 
-      const ringOuter = new THREE.Mesh(new THREE.TorusGeometry(1.4, 0.08, 24, 128), ringMat);
-      this.scene.add(ringOuter);
-      const ringInner = new THREE.Mesh(new THREE.TorusGeometry(0.95, 0.06, 24, 128), ringMat);
-      this.scene.add(ringInner);
+      const innerRing = new THREE.Mesh(new THREE.TorusGeometry(0.95, 0.06, 16, 96), ringMat);
+      innerRing.rotation.x = Math.PI/2;
+      this.scene.add(innerRing);
 
-      this.docks = [];
-      for(let i=0;i<6;i++){
-        const a = i * Math.PI*2/6;
-        const m = new THREE.Mesh(new THREE.SphereGeometry(0.22, 32, 24), coreMat);
-        m.position.set(Math.cos(a)*0.9, 0, Math.sin(a)*0.9);
-        this.scene.add(m);
-        this.docks.push(m);
+      const disk = new THREE.Mesh(new THREE.CylinderGeometry(0.9, 0.9, 0.08, 72), innerMat);
+      disk.rotation.x = Math.PI/2;
+      this.scene.add(disk);
+
+      const hub = new THREE.Mesh(new THREE.SphereGeometry(0.28, 48, 32), hubMat);
+      this.scene.add(hub);
+
+      const spokes = 8;
+      for (let i=0;i<spokes;i++){
+        const a = i*(Math.PI*2/spokes);
+        const r = 1.12;
+        const cyl = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.02, r, 12), spokeMat);
+        cyl.position.set(Math.cos(a)*r/2, Math.sin(a)*r/2, 0);
+        cyl.rotation.z = a + Math.PI/2;
+        this.scene.add(cyl);
+        const pod = new THREE.Mesh(new THREE.SphereGeometry(0.18, 36, 24), hubMat);
+        pod.position.set(Math.cos(a)*r, Math.sin(a)*r, 0);
+        this.scene.add(pod);
       }
 
-      const halo = new THREE.Mesh(new THREE.RingGeometry(0.65, 1.65, 64, 1), new THREE.MeshBasicMaterial({ color: 0x5ec8ff, transparent: true, opacity: 0.12, side: THREE.DoubleSide }));
-      halo.rotation.x = Math.PI/2;
-      this.scene.add(halo);
-
-      this.core = core;
-      this.ringOuter = ringOuter;
-      this.ringInner = ringInner;
-
-      this._ready = true;
+      this.root = new THREE.Group();
+      this.root.add(outerRing, innerRing, disk, hub);
+      this.scene.add(this.root);
     }
 
     render(dt){
-      this._initIfNeeded();
-      if (!this._ready) return;
+      this._lazyInit();
+      if(!this.scene || !this.camera) return;
 
-      if (this.sunRef && this._dirLight && this.ref){
-        const dx = this.ref.x - this.sunRef.x;
-        const dy = this.ref.y - this.sunRef.y;
-        const len = Math.hypot(dx, dy) || 1;
-        this._dirLight.position.set(dx/len, 0.4, dy/len);
-      }
-
-      this.ringOuter.rotation.y += this.spin * dt * 0.5;
-      this.ringInner.rotation.y -= this.spin * dt * 0.7;
+      if (this.root) this.root.rotation.z += this.spin * dt;
 
       const r = getSharedRenderer(this.canvas.width, this.canvas.height);
-      if (!r) return;
+      if(!r) return;
       r.setClearColor(0x000000, 0);
       r.render(this.scene, this.camera);
 
@@ -424,14 +420,10 @@
     }
 
     draw(ctx, cam){
-      if (!this._ready || !this.ref) return;
-      const s = worldToScreen(this.ref.x, this.ref.y, cam);
-      const scale = (window.DevTuning?.pirateStationScale ?? 1.0);
-      const pxSize = (this.ref.baseR || this.ref.r) * 2 * scale * cam.zoom;
-      ctx.drawImage(this.canvas, s.x - pxSize/2, s.y - pxSize/2, pxSize, pxSize);
+      const s = worldToScreen(this.x, this.y, cam);
+      const size = this.size * cam.zoom;
+      ctx.drawImage(this.canvas, s.x - size/2, s.y - size/2, size, size);
     }
-
-    get ready(){ return this._ready; }
   }
 
   // ======= API zgodne z proceduralnym rendererem =======
@@ -458,33 +450,43 @@
       asteroidBelt = null;
     }
 
-    const stList = (typeof window !== 'undefined' ? window.stations : null) || [];
-    const pirate = stList.find(s => s.isPirate || s.type === 'pirate' || /pir/i.test(s?.name || s?.label || ''));
-    if (pirate) {
-      if (pirate.baseR == null) pirate.baseR = pirate.r;
-      pirate3D = new PirateStation3D(pirate, sunObj || {x:0,y:0});
-    } else {
-      pirate3D = null;
-    }
   };
 
   window.updatePlanets3D = function updatePlanets3D(dt) {
     if (sun) sun.render(dt);
     if (asteroidBelt) asteroidBelt.render(dt);
     for (const p of _planets) p.render(dt);
-    if (pirate3D) pirate3D.render(dt);
   };
 
   window.drawPlanets3D = function drawPlanets3D(ctx, cam) {
     if (asteroidBelt) asteroidBelt.draw(ctx, cam);
     for (const p of _planets) p.draw(ctx, cam);
     if (sun) sun.draw(ctx, cam);
-    if (pirate3D && pirate3D.ready && window.DevFlags?.use3DPirateStation) {
-      pirate3D.draw(ctx, cam);
+  };
+
+  window.initStations3D = function initStations3D(list){
+    _stations3D.length = 0;
+    if (!Array.isArray(list)) return;
+    for (const st of list){
+      const px = st.x ?? 0, py = st.y ?? 0;
+      const size = (st.r || 260) * 2.8;
+      const s3d = new PirateStation3D(px, py, size, {});
+      _stations3D.push(s3d);
     }
   };
 
-  window.isPirate3DReady = () => !!(pirate3D && pirate3D.ready);
+  window.updateStations3D = function updateStations3D(dt){
+    for (const s of _stations3D) s.render(dt);
+  };
+
+  window.drawStations3D = function drawStations3D(ctx, cam){
+    for (const s of _stations3D) s.draw(ctx, cam);
+  };
+
+  window.__setStation3DScale = function(k){
+    for (const s of _stations3D) s.size = (s.size||800) * (k / (window.__lastStationScale||1));
+    window.__lastStationScale = k;
+  };
 
   window.getSharedRenderer = getSharedRenderer;
 })();


### PR DESCRIPTION
## Summary
- add a reusable PirateStation3D asset pipeline using the shared WebGL renderer and expose init/update/draw APIs for stations
- integrate the station overlay into the main render loop, disable the 2D fallback when 3D is active, and initialise overlays for generated stations
- extend DevTools with station 3D scale controls and persistence, keeping the new overlay configurable

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68df9ce4ad7883259c825571054ba457