### PR TITLE
Fix overlay 3D canvas layering and transparency

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,15 @@
   .hp-hangar h4, .hp-hangar .hp-item { outline:1px solid #a78bfa; }
   .hp-spec   h4, .hp-spec .hp-item   { outline:1px solid #ef4444; }
 </style>
+<style>
+  /* Overlay 3D musi być nad głównym canvasem (#c) */
+  canvas.overlay3d {
+    position: absolute;
+    inset: 0;
+    pointer-events: none !important;
+    z-index: 20;
+  }
+</style>
 </head>
 <body>
   <div id="ui">

--- a/src/effects3d/overlay.js
+++ b/src/effects3d/overlay.js
@@ -5,23 +5,29 @@ export function initOverlay({ host, getView }) {
     throw new Error("initOverlay: host element is required");
   }
 
-  const canvas = document.createElement("canvas");
-  Object.assign(canvas.style, {
-    position: "absolute",
-    inset: "0",
-    pointerEvents: "none",
-    zIndex: 15,
+  const renderer = new THREE.WebGLRenderer({
+    antialias: true,
+    alpha: true,
+    premultipliedAlpha: true,
   });
-  host.appendChild(canvas);
+  renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+  renderer.setSize(host.clientWidth, host.clientHeight, false);
 
-  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
   renderer.autoClear = true;
   renderer.setClearColor(0x000000, 0);
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.05;
-  renderer.setSize(host.clientWidth, host.clientHeight, false);
+
+  const dom = renderer.domElement;
+  dom.classList.add("overlay3d");
+  dom.style.pointerEvents = "none";
+  dom.style.position = "absolute";
+  dom.style.inset = "0";
+  dom.style.zIndex = "20";
+  dom.style.background = "transparent";
+
+  host.appendChild(dom);
 
   const scene = new THREE.Scene();
 
@@ -98,8 +104,8 @@ export function initOverlay({ host, getView }) {
 
   function dispose() {
     effects.length = 0;
-    if (canvas.parentElement === host) {
-      host.removeChild(canvas);
+    if (dom.parentElement === host) {
+      host.removeChild(dom);
     }
     renderer.dispose();
   }


### PR DESCRIPTION
## Summary
- ensure the overlay WebGL canvas uses the overlay3d class with transparent layering styles
- configure the overlay renderer with alpha/premultiplied alpha and pointer-event safe DOM setup before attaching to the host

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dfb020e51c8325ba057f43530b9766