### PR TITLE
Adjust overlay canvas stacking order

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,13 @@
   #game-root{position:relative;width:100vw;height:100vh;}
   #game-root>canvas{display:block;width:100%;height:100%;}
   #c { position: relative; z-index: 10; }
-  canvas:not(#c) { pointer-events: none !important; position: absolute; inset: 0; z-index: 0; }
+  /* nie obejmuj overlayu 3D */
+  canvas:not(#c):not(.overlay3d) {
+    pointer-events: none !important;
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
   .stat{font-family:monospace;font-size:13px}
   small{color:#a8b4d9}
   #loading{position:fixed;left:0;top:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:#030417;z-index:50;color:#dfe7ff;font-size:32px;font-family:Inter,system-ui,Segoe UI,Roboto,Arial}
@@ -44,7 +50,7 @@
     position: absolute;
     inset: 0;
     pointer-events: none !important;
-    z-index: 20;
+    z-index: 30 !important;
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- exclude the 3D overlay canvas from the generic absolute-positioning rule and comment its purpose
- raise the overlay canvas z-index so it sits above other layers when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dfc7010d588325b843d4ab7c2f5656