### PR TITLE
Scale railgun explosion effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,9 +599,9 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 // Helper do spawnu eksplozji 3D
-function triggerRailgunExplosion3D(x, y){
+function triggerRailgunExplosion3D(x, y, size = ship.h * 0.22){
   if (overlay3D && window.makeRailgunExplosion) {
-    const fx = window.makeRailgunExplosion({ x, y });
+    const fx = window.makeRailgunExplosion({ x, y, size });
     overlay3D.spawn(fx);
   }
 }
@@ -1257,13 +1257,8 @@ function spawnExplosionPlasma(x,y,scale=1){
   }
 }
 function spawnRailHitEffect(x,y,scale=1){
-  for(let i=0;i<12 * scale;i++){
-    const a = Math.random()*Math.PI*2;
-    const s = 80 + Math.random()*220 * scale;
-    spawnParticle({x,y}, {x:Math.cos(a)*s, y:Math.sin(a)*s}, 0.25 + Math.random()*0.35, '#bfe7ff', 1 + Math.random()*2, true);
-  }
-  spawnParticle({x,y}, {x:0,y:0}, 0.12, '#ffffff', 6 * scale, true);
-  triggerRailgunExplosion3D(x, y);
+  // Tylko 3D (skalowane parametrem efektu)
+  triggerRailgunExplosion3D(x, y, ship.h * 0.22 * scale);
 }
 function spawnDefaultHit(x,y,scale=1){
   for(let i=0;i<14*scale;i++){

--- a/src/effects3d/railgunExplosion.js
+++ b/src/effects3d/railgunExplosion.js
@@ -17,9 +17,10 @@ function ensureTextures() {
 export function createRailgunExplosionFactory(scene) {
   ensureTextures();
 
-  return function spawn({ x = 0, y = 0, z } = {}) {
+  return function spawn({ x = 0, y = 0, z, size = 50 } = {}) {
     const group = new THREE.Group();
     group.position.set(x, 0, z !== undefined ? z : y);
+    group.scale.setScalar(size);
     scene.add(group);
 
     const flashMaterial = new THREE.SpriteMaterial({
@@ -119,13 +120,14 @@ export function createRailgunExplosionFactory(scene) {
       group.add(smoke);
     }
 
-    const light = new THREE.PointLight(0x9ad9ff, 120, 110, 2);
+    const light = new THREE.PointLight(0x9ad9ff, 120, 110 * size, 2);
     light.position.set(0, 6, 0);
     group.add(light);
 
     const duration = 0.6;
     let time = 0;
     let disposed = false;
+    const sizeBoost = Math.sqrt(size / 50);
 
     function update(dt) {
       if (disposed) return;
@@ -178,7 +180,7 @@ export function createRailgunExplosionFactory(scene) {
         }
       }
 
-      light.intensity = 140 * Math.max(0, 1 - time / 0.12);
+      light.intensity = 140 * sizeBoost * Math.max(0, 1 - time / 0.12);
 
       if (time > duration + 0.6) {
         dispose();


### PR DESCRIPTION
## Summary
- add a size parameter to the railgun explosion factory and scale the light with it
- expose the explosion size through the trigger helper and map the 2D API to the new scaling
- remove the legacy 2D particle hit effect in favour of the 3D explosion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e24dc9680883258659101ca5504898