### PR TITLE
refactor: extract AI into dedicated module

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,16 @@
 <!-- przełącznik: aktywuj assetowy renderer planet (klasyczny skrypt, aby globalne API było gotowe zanim ruszy pętla gry) -->
 <script src="planet3d.assets.js"></script>
 
-<script>
+<script type="module">
+import {
+  steerToward,
+  chaseEvadeAI,
+  dogfightAI,
+  battleshipAI,
+  limitSpeed,
+  wrapAngle,
+  leadTarget,
+} from "./src/ai/ai.js";
 // =============== Canvas & utils ===============
 const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
@@ -517,34 +526,8 @@ function formatGameTime(sec){
   const m = Math.floor((t % 3600) / 60);
   return `${h.toString().padStart(2,'0')}:${m.toString().padStart(2,'0')}`;
 }
-function wrapAngle(a){ while(a>Math.PI) a-=2*Math.PI; while(a<-Math.PI) a+=2*Math.PI; return a; }
 function interpAngleShort(prev,curr,t){ const d = wrapAngle(curr - prev); return wrapAngle(prev + d * t); }
 function shuffleArray(a){ for(let i=a.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } }
-function leadTarget(shooter, shooterVel, target, speed){
-  const tx = target.x, ty = target.y;
-  const tvx = target.vx || 0, tvy = target.vy || 0;
-  const rx = tx - shooter.x, ry = ty - shooter.y;
-  const rvx = tvx - shooterVel.x, rvy = tvy - shooterVel.y;
-  const a = rvx*rvx + rvy*rvy - speed*speed;
-  const b = 2*(rx*rvx + ry*rvy);
-  const c = rx*rx + ry*ry;
-  let t = 0;
-  if(Math.abs(a) < 1e-6){
-    if(Math.abs(b) > 1e-6) t = -c / b;
-  } else {
-    const disc = b*b - 4*a*c;
-    if(disc >= 0){
-      const sqrtDisc = Math.sqrt(disc);
-      const t1 = (-b - sqrtDisc)/(2*a);
-      const t2 = (-b + sqrtDisc)/(2*a);
-      t = Math.min(t1, t2);
-      if(t < 0) t = Math.max(t1, t2);
-    }
-  }
-  if(!isFinite(t) || t < 0) t = 0;
-  return { x: tx + tvx*t, y: ty + tvy*t };
-}
-
 // =============== World / camera ===============
 const WORLD = { w: 120000, h: 80000 };
 const camera = {
@@ -1077,7 +1060,7 @@ function spawnDestroyer(pos){
     rocketR: makeRocketPod({ salvo: 3, cooldown: 2.8 })
   };
   n.ai = function(dt){
-    battleshipAI(n, ship);
+    battleshipAI(n, ship, WORLD);
     useRailPair(n, ship);
     useRocketsPair(n, ship);
   };
@@ -1100,7 +1083,7 @@ function spawnGunship(pos){
     rockets: makeRocketPod({ salvo: 2, cooldown: 3.2 })
   };
   n.ai = function(dt){
-    dogfightAI(n, ship);
+    dogfightAI(n, ship, WORLD);
     useCIWSPair(n, ship);
     maybeFireRockets(n, ship);
   };
@@ -2265,7 +2248,7 @@ function guardAI(n, dt){
   n.orbitAngle = (n.orbitAngle + w*dt) % (Math.PI*2);
   const target = { x: st.x + Math.cos(n.orbitAngle)*n.orbitRadius,
                    y: st.y + Math.sin(n.orbitAngle)*n.orbitRadius };
-  steerToward(n, target.x, target.y, dt, n.accel*0.8, n.turn*0.8);
+  steerToward(n, target, { dt, accel: n.accel*0.8, turnRate: n.turn*0.8 });
   const drag = Math.exp(-0.8*dt);
   n.vx *= drag; n.vy *= drag;
 }
@@ -4857,52 +4840,6 @@ function applyShipStats(s){
 }
 
 function dist(x1,y1,x2,y2){ return Math.hypot(x2-x1, y2-y1); }
-function limitSpeed(n, max){
-  const vx = n.vel ? n.vel.x : n.vx;
-  const vy = n.vel ? n.vel.y : n.vy;
-  const v = Math.hypot(vx, vy);
-  if(v>max){
-    const s = max/v;
-    if(n.vel){ n.vel.x*=s; n.vel.y*=s; }
-    else { n.vx*=s; n.vy*=s; }
-  }
-}
-function steerToward(n, tx, ty, dt, accel = n.accel, turnRate = n.turn) {
-  const desired = Math.atan2(ty - n.y, tx - n.x);
-  const diff = wrapAngle(desired - n.angle);
-  const turn = clamp(diff, -turnRate * dt, turnRate * dt);
-  n.angle = wrapAngle(n.angle + turn);
-  n.vx += Math.cos(n.angle) * accel * dt;
-  n.vy += Math.sin(n.angle) * accel * dt;
-  limitSpeed(n, n.maxSpeed);
-}
-
-function chaseEvadeAI(n, target, opts = {}) {
-  steerToward(n, target.pos.x, target.pos.y, 0.016);
-
-  if (opts.strafe) {
-    const side = (Math.random() < 0.5 ? -1 : 1);
-    const ang = n.angle + side * Math.PI / 2;
-    n.vx += Math.cos(ang) * n.accel * 0.004;
-    n.vy += Math.sin(ang) * n.accel * 0.004;
-  }
-}
-
-function dogfightAI(n, target) {
-  chaseEvadeAI(n, target, { strafe: true });
-}
-
-function battleshipAI(n, target) {
-  const d = Math.hypot(target.pos.x - n.x, target.pos.y - n.y);
-  if (d < 600) {
-    const ang = Math.atan2(n.y - target.pos.y, n.x - target.pos.x);
-    n.vx += Math.cos(ang) * n.accel * 0.016;
-    n.vy += Math.sin(ang) * n.accel * 0.016;
-    limitSpeed(n, n.maxSpeed);
-  } else {
-    chaseEvadeAI(n, target);
-  }
-}
 function useRailPair(n, target){ /* sprawdź kąt i cooldown, odpal pary */ }
 function useRocketsPair(n, target){ /* salwy */ }
 function useCIWSPair(n, target){ /* krótka seria */ }

--- a/src/ai/ai.js
+++ b/src/ai/ai.js
@@ -1,0 +1,156 @@
+const DEFAULT_DT = 0.016;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function wrapAngle(angle) {
+  let a = angle;
+  while (a > Math.PI) a -= 2 * Math.PI;
+  while (a < -Math.PI) a += 2 * Math.PI;
+  return a;
+}
+
+function resolveTargetPosition(target) {
+  if (!target) {
+    return { x: 0, y: 0 };
+  }
+  if (typeof target.x === 'number' && typeof target.y === 'number') {
+    return { x: target.x, y: target.y };
+  }
+  if (target.pos && typeof target.pos.x === 'number' && typeof target.pos.y === 'number') {
+    return { x: target.pos.x, y: target.pos.y };
+  }
+  return { x: 0, y: 0 };
+}
+
+export function limitSpeed(entity, max) {
+  const vx = entity.vel ? entity.vel.x : entity.vx;
+  const vy = entity.vel ? entity.vel.y : entity.vy;
+  const v = Math.hypot(vx, vy);
+  if (v > max) {
+    const s = max / v;
+    if (entity.vel) {
+      entity.vel.x *= s;
+      entity.vel.y *= s;
+    } else {
+      entity.vx *= s;
+      entity.vy *= s;
+    }
+  }
+}
+
+export function leadTarget(shooter, shooterVel, target, speed) {
+  const targetPos = resolveTargetPosition(target);
+  const tx = targetPos.x;
+  const ty = targetPos.y;
+  const tvx = target.vx ?? (target.vel ? target.vel.x : 0);
+  const tvy = target.vy ?? (target.vel ? target.vel.y : 0);
+  const rx = tx - shooter.x;
+  const ry = ty - shooter.y;
+  const rvx = tvx - shooterVel.x;
+  const rvy = tvy - shooterVel.y;
+  const a = rvx * rvx + rvy * rvy - speed * speed;
+  const b = 2 * (rx * rvx + ry * rvy);
+  const c = rx * rx + ry * ry;
+  let t = 0;
+  if (Math.abs(a) < 1e-6) {
+    if (Math.abs(b) > 1e-6) t = -c / b;
+  } else {
+    const disc = b * b - 4 * a * c;
+    if (disc >= 0) {
+      const sqrtDisc = Math.sqrt(disc);
+      const t1 = (-b - sqrtDisc) / (2 * a);
+      const t2 = (-b + sqrtDisc) / (2 * a);
+      t = Math.min(t1, t2);
+      if (t < 0) t = Math.max(t1, t2);
+    }
+  }
+  if (!Number.isFinite(t) || t < 0) t = 0;
+  return { x: tx + tvx * t, y: ty + tvy * t };
+}
+
+export function steerToward(entity, target, params = {}) {
+  const { dt = DEFAULT_DT } = params;
+  const accel = params.accel ?? entity.accel;
+  const turnRate = params.turnRate ?? entity.turn;
+  const maxSpeed = params.maxSpeed ?? entity.maxSpeed;
+  const { x: tx, y: ty } = resolveTargetPosition(target);
+  const desired = Math.atan2(ty - entity.y, tx - entity.x);
+  const currentAngle = entity.angle ?? 0;
+  const diff = wrapAngle(desired - currentAngle);
+  const turn = clamp(diff, -turnRate * dt, turnRate * dt);
+  const newAngle = wrapAngle(currentAngle + turn);
+  entity.angle = newAngle;
+  if (accel) {
+    entity.vx = (entity.vx ?? 0) + Math.cos(newAngle) * accel * dt;
+    entity.vy = (entity.vy ?? 0) + Math.sin(newAngle) * accel * dt;
+  }
+  if (maxSpeed != null) {
+    limitSpeed(entity, maxSpeed);
+  }
+}
+
+export function chaseEvadeAI(npc, target, opts = {}) {
+  if (!npc || !target) return;
+  const dt = opts.dt ?? DEFAULT_DT;
+  steerToward(npc, target, {
+    dt,
+    accel: opts.accel ?? npc.accel,
+    turnRate: opts.turnRate ?? npc.turn,
+    maxSpeed: npc.maxSpeed,
+  });
+
+  if (opts.strafe) {
+    const side = opts.strafeDir ?? (Math.random() < 0.5 ? -1 : 1);
+    const ang = (npc.angle ?? 0) + (side * Math.PI) / 2;
+    const strafeAccel = opts.strafeAccel ?? npc.accel * 0.25;
+    npc.vx = (npc.vx ?? 0) + Math.cos(ang) * strafeAccel * dt;
+    npc.vy = (npc.vy ?? 0) + Math.sin(ang) * strafeAccel * dt;
+  }
+}
+
+export function dogfightAI(npc, player, world, tuning = {}) {
+  if (!npc || !player) return;
+  const dt = tuning.dt ?? DEFAULT_DT;
+  chaseEvadeAI(npc, player, { dt, strafe: true });
+}
+
+export function battleshipAI(npc, targets, world, tuning = {}) {
+  if (!npc) return;
+  const dt = tuning.dt ?? DEFAULT_DT;
+  const retreatRange = tuning.retreatRange ?? 600;
+  const target = Array.isArray(targets)
+    ? targets.find((t) => t && !t.dead) || targets[0]
+    : targets;
+  if (!target) return;
+  const { x: tx, y: ty } = resolveTargetPosition(target);
+  const dx = tx - npc.x;
+  const dy = ty - npc.y;
+  const dist = Math.hypot(dx, dy);
+
+  if (dist < retreatRange) {
+    const ang = Math.atan2(npc.y - ty, npc.x - tx);
+    npc.vx = (npc.vx ?? 0) + Math.cos(ang) * npc.accel * dt;
+    npc.vy = (npc.vy ?? 0) + Math.sin(ang) * npc.accel * dt;
+    limitSpeed(npc, npc.maxSpeed);
+  } else {
+    chaseEvadeAI(npc, target, { dt });
+  }
+}
+
+export const AIUtils = {
+  wrapAngle,
+  leadTarget,
+  limitSpeed,
+};
+
+export default {
+  steerToward,
+  chaseEvadeAI,
+  dogfightAI,
+  battleshipAI,
+  leadTarget,
+  wrapAngle,
+  limitSpeed,
+};


### PR DESCRIPTION
## Summary
- move AI steering helpers and behaviours into src/ai/ai.js with exported steerToward, dogfightAI, and battleshipAI APIs
- convert the main game script to an ES module that imports the AI helpers and updates call sites without changing runtime behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2622e0f108325975f8b040dc970f1