### PR TITLE
Fix PreserveAlpha shader chunk injection

### DIFF
--- a/src/3d/world3d.js
+++ b/src/3d/world3d.js
@@ -68,8 +68,8 @@ const PreserveAlphaOutputShader = {
 
     varying vec2 vUv;
 
-    #include <tonemapping_pars_fragment>
-    #include <colorspace_pars_fragment>
+    ${THREE.ShaderChunk['tonemapping_pars_fragment']}
+    ${THREE.ShaderChunk['colorspace_pars_fragment']}
 
     void main() {
       gl_FragColor = texture2D(tDiffuse, vUv);


### PR DESCRIPTION
## Summary
- inject tonemapping and colorspace shader chunks once via template strings in PreserveAlphaOutputShader
- ensure the post-processing composer uses only render, bloom, and preserve-alpha passes with the alpha-preserving pass rendering to screen

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e5027c0a5883259a0edb40aad6955f