### PR TITLE
Scale up solar system defaults and slow asteroid belt

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,8 +146,11 @@ window.DevFlags = Object.assign({
   use3DPirateStation: true
 }, window.DevFlags || {});
 
+const DEFAULT_PLANET_SCALE = 3;
+const DEFAULT_STATION_SCALE = 3;
+
 window.DevTuning = Object.assign({
-  pirateStationScale: 1.0
+  pirateStationScale: DEFAULT_STATION_SCALE
 }, window.DevTuning || {});
 
 const DevFlags = window.DevFlags;
@@ -546,7 +549,7 @@ function leadTarget(shooter, shooterVel, target, speed){
 }
 
 // =============== World / camera ===============
-const WORLD = { w: 120000, h: 80000 };
+const WORLD = { w: 240000, h: 160000 };
 const camera = {
   zoom: 1.0,
   defaultZoom: 1.0,
@@ -786,7 +789,7 @@ function initStars(reset=false){
 }
 
 // =============== Słońce, planety i stacje ===============
-const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 200,
+const SUN = { x: WORLD.w/2, y: WORLD.h/2, r: 1000,
   color: {
     core:  '#ffe88a',   // jasno-żółty rdzeń
     mid:   '#ffbe3b',   // pomarańcz-żółć
@@ -809,18 +812,43 @@ const USE_SOLAR = solarParams.has('solar') ? solarParams.get('solar') !== '0' : 
 function makeSolarPlanets(){
   // Skala: 1 AU ≈ 3000 jednostek świata (Neptun ~ 90k)
   const AU = 3000;
+  const MIN_SUN_GAP = 600;
+  const MIN_PLANET_GAP = 800;
   const rand = () => Math.random() * Math.PI * 2;
-  return [
-    { id:'mercury', name:'mercury', r:  44, orbitRadius: 0.39*AU, angle: rand(), speed: 0 },
-    { id:'venus',   name:'venus',   r:  60, orbitRadius: 0.72*AU, angle: rand(), speed: 0 },
-    { id:'earth',   name:'earth',   r:  64, orbitRadius: 1.00*AU, angle: rand(), speed: 0 },
-    { id:'mars',    name:'mars',    r:  54, orbitRadius: 1.52*AU, angle: rand(), speed: 0 },
-    { id:'jupiter', name:'jupiter', r: 160, orbitRadius: 5.20*AU, angle: rand(), speed: 0 },
-    { id:'saturn',  name:'saturn',  r: 140, orbitRadius: 9.58*AU, angle: rand(), speed: 0 },
-    { id:'uranus',  name:'uranus',  r: 108, orbitRadius:19.20*AU, angle: rand(), speed: 0 },
-    { id:'neptune', name:'neptune', r: 104, orbitRadius:30.00*AU, angle: rand(), speed: 0 },
-    // { id:'pluto',   name:'pluto',   r:  30, orbitRadius:39.50*AU, angle: rand(), speed: 0 },
+  const defs = [
+    { id:'mercury', name:'mercury', baseR:  44, orbitAU: 0.39 },
+    { id:'venus',   name:'venus',   baseR:  60, orbitAU: 0.72 },
+    { id:'earth',   name:'earth',   baseR: 129, orbitAU: 1.00 },
+    { id:'mars',    name:'mars',    baseR: 191, orbitAU: 1.52 },
+    { id:'jupiter', name:'jupiter', baseR: 400, orbitAU: 5.20 },
+    { id:'saturn',  name:'saturn',  baseR: 180, orbitAU: 9.58 },
+    { id:'uranus',  name:'uranus',  baseR: 108, orbitAU:19.20 },
+    { id:'neptune', name:'neptune', baseR: 104, orbitAU:30.00 },
+    // { id:'pluto',   name:'pluto',   baseR:  30, orbitAU:39.50 },
   ];
+
+  let minOrbitEdge = SUN.r;
+  return defs.map((def) => {
+    const effectiveR = def.baseR * DEFAULT_PLANET_SCALE;
+    const baseOrbit = def.orbitAU * AU;
+    const orbitRadius = Math.max(
+      baseOrbit,
+      SUN.r + effectiveR + MIN_SUN_GAP,
+      minOrbitEdge + effectiveR + MIN_PLANET_GAP
+    );
+
+    minOrbitEdge = orbitRadius + effectiveR;
+
+    return {
+      id: def.id,
+      name: def.name,
+      baseR: def.baseR,
+      r: effectiveR,
+      orbitRadius,
+      angle: rand(),
+      speed: 0
+    };
+  });
 }
 
 // jeśli kiedyś będziemy chcieli wrócić do starych zasad, zostawiamy helper:
@@ -881,6 +909,10 @@ function formatPlanetLabel(planet, index){
 
 // wylicz pozycje
 let planets = PLANET_DATA.map((p, index) => {
+  if (p.baseR == null) p.baseR = p.r;
+  if (p.r == null && p.baseR != null) {
+    p.r = p.baseR * DEFAULT_PLANET_SCALE;
+  }
   p.x = SUN.x + Math.cos(p.angle) * p.orbitRadius;
   p.y = SUN.y + Math.sin(p.angle) * p.orbitRadius;
   p.label = formatPlanetLabel(p, index);
@@ -5043,7 +5075,7 @@ setTimeout(startGame, 500);
     <div class="row"><strong>Wszechświat</strong></div>
     <div class="row">
       <label>Słońce – promień (R)</label>
-      <input id="sunR" type="range" min="50" max="600" step="1">
+      <input id="sunR" type="range" min="50" max="1500" step="1">
       <div class="val" id="sunRVal"></div>
     </div>
     <div class="row">
@@ -5067,7 +5099,7 @@ setTimeout(startGame, 500);
     </div>
     <div class="row">
       <label>Skala stacji 3D (×)</label>
-      <input id="station3DScale" type="range" min="0.2" max="3.0" step="0.05" value="1.0">
+      <input id="station3DScale" type="range" min="0.2" max="3.0" step="0.05" value="3.0">
       <div class="val" id="station3DScaleVal"></div>
     </div>
     <label style="display:flex;gap:6px;align-items:center;margin-top:8px">
@@ -5108,9 +5140,9 @@ setTimeout(startGame, 500);
   const DevConfig = {
     sunR: null,                 // liczba — promień Słońca (SUN.r)
     planetRById: {},            // { [id or name]: R }
-    planetScaleAll: 1,          // mnożnik globalny ×R
-    pirateScale: 1.0,           // mnożnik rysowania stacji pirackiej
-    station3DScale: 1.0,        // mnożnik nakładki 3D
+    planetScaleAll: DEFAULT_PLANET_SCALE,          // mnożnik globalny ×R
+    pirateScale: DEFAULT_STATION_SCALE,           // mnożnik rysowania stacji pirackiej
+    station3DScale: DEFAULT_STATION_SCALE,        // mnożnik nakładki 3D
   };
   const DevFlags = window.DevFlags;
   window.DevConfig = DevConfig;
@@ -5137,7 +5169,8 @@ setTimeout(startGame, 500);
     // domyślne per-planeta (key = name lub id)
     for (const p of planets) {
       const key = (p.name || p.id || String(p.index)||'').toString().toLowerCase();
-      if (!DevConfig.planetRById[key]) DevConfig.planetRById[key] = p.r;
+      const baseR = p.baseR ?? p.r;
+      if (baseR != null && !DevConfig.planetRById[key]) DevConfig.planetRById[key] = baseR;
     }
   }
 
@@ -5159,6 +5192,9 @@ setTimeout(startGame, 500);
         Object.assign(DevFlags, flags);
       }
     } catch {}
+    if (typeof DevConfig.planetScaleAll !== 'number') {
+      DevConfig.planetScaleAll = DEFAULT_PLANET_SCALE;
+    }
     if (typeof DevConfig.pirateScale !== 'number') {
       DevConfig.pirateScale = DevTuning.pirateStationScale;
     }
@@ -5183,11 +5219,14 @@ setTimeout(startGame, 500);
     rebuildTimer = requestAnimationFrame(()=> {
       // aktualizujemy struktury gry na podstawie DevConfig
       SUN.r = DevConfig.sunR|0;
-      const scaleAll = +DevConfig.planetScaleAll || 1;
+      const scaleAll = +DevConfig.planetScaleAll || DEFAULT_PLANET_SCALE;
       for (const p of planets) {
         const key = (p.name || p.id || String(p.index)||'').toString().toLowerCase();
-        const base = DevConfig.planetRById[key] ?? p.r;
-        p.r = Math.max(1, Math.round(base * scaleAll));
+        const base = DevConfig.planetRById[key] ?? p.baseR ?? p.r;
+        if (base != null) {
+          p.baseR = base;
+          p.r = Math.max(1, Math.round(base * scaleAll));
+        }
       }
       // Odbudowa warstwy 3D
       if (typeof initPlanets3D === 'function') initPlanets3D(planets, SUN);

--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -243,8 +243,8 @@
       this.canvas = document.createElement('canvas');
       this.canvas.width = 1024; this.canvas.height = 1024;
       this.ctx2d = this.canvas.getContext('2d');
-      this.spin = 0.02;
-      this.rotSpeed = 0.05;
+      this.spin = 0.004;
+      this.rotSpeed = 0.01;
 
       if (typeof THREE === 'undefined') return;
       this.scene = new THREE.Scene();
@@ -298,7 +298,7 @@
             imesh.receiveShadow = true;
             this.root.add(imesh);
             this.imesh = imesh;
-            this.spin = 0.04; // bardzo wolna rotacja
+            this.spin = 0.008; // bardzo wolna rotacja
           }
         );
       };

--- a/planet3d.js
+++ b/planet3d.js
@@ -486,7 +486,7 @@
       this.scene.add(this.mesh);
 
       this._instanced = [];
-      this.rotationSpeed = 0.03;
+      this.rotationSpeed = 0.006;
       this.rotation = 0;
 
       const inner = innerRadius / outerRadius;

--- a/planet3d.proc.js
+++ b/planet3d.proc.js
@@ -772,7 +772,7 @@ const PLANET_FRAG = `// Terrain generation parameters
       this.scene.add(this.mesh);
 
       this._instanced = [];
-      this.rotationSpeed = 0.03;
+      this.rotationSpeed = 0.006;
       this.rotation = 0;
 
       const inner = innerRadius / outerRadius;


### PR DESCRIPTION
## Summary
- enlarge the playable world, sun, and planetary defaults while spacing orbits for the bigger bodies
- align devtools defaults and sliders with the new scale configuration values
- slow the asteroid belt rotation across all 3D renderers for a calmer appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e54976e7688325bedf9d6313aa48d1