### PR TITLE
Align planet renderer settings

### DIFF
--- a/planet3d.assets.js
+++ b/planet3d.assets.js
@@ -13,6 +13,8 @@
         preserveDrawingBuffer: false
       });
       sharedRenderer.outputColorSpace = THREE.SRGBColorSpace;
+      sharedRenderer.toneMapping = THREE.ACESFilmicToneMapping;
+      sharedRenderer.toneMappingExposure = 1.25;
       sharedRenderer.autoClear = true;
       sharedRenderer.setClearColor(0x000000, 0);
       // cienie
@@ -181,6 +183,8 @@
 
       const r = getSharedRenderer(this.canvas.width, this.canvas.height);
       if (!r) return;
+      if (r.state && r.state.reset) r.state.reset();
+      r.setScissorTest(false);
       r.setClearColor(0x000000, 0);
       r.render(this.scene, this.camera);
 


### PR DESCRIPTION
## Summary
- align the shared planet renderer tone mapping and clear color with the world renderer
- reset the shared renderer state before each planet render to avoid leftover scissor settings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e55e07a7148325a0d28ccf9c85750d