### PR TITLE
Guard DevTools distance slider initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -5624,7 +5624,7 @@ setTimeout(startGame, 500);
   loadLS();
   bootstrapFromGame();
   buildPlanetsUI();        // promienie planet (R)
-  buildDistancesUI();      // suwaki AU
+  if (typeof buildDistancesUI === 'function') buildDistancesUI();      // suwaki AU
   reflectToUI();
   reflectToCfg();
   scheduleRebuild3D();


### PR DESCRIPTION
## Summary
- ensure the distance-slider UI build step runs only when the builder function is present during DevTools boot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e64cc588d08325b0c5e464888d4a6f